### PR TITLE
feat!: add prettier CLI via Typer [DEV-11110 DEV-11138]

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -18,7 +18,7 @@ steps:
       password:
         from_secret: harbor_password
       registry: harbor.devops.indico.io
-      repo: harbor.devops.indico.io/indico/virga
+      repo: harbor.devops.indico.io/indico/virga_testsuite
       tags:
         - ${DRONE_COMMIT_SHA}.unittest
       squash: true
@@ -48,7 +48,7 @@ steps:
       APP_REDIS_HOST: localhost
 
   - name: test
-    image: harbor.devops.indico.io/indico/virga:${DRONE_COMMIT_SHA}.unittest
+    image: harbor.devops.indico.io/indico/virga_testsuite:${DRONE_COMMIT_SHA}.unittest
     commands:
       - ./scripts/run_tests.sh
     environment:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,9 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: File a bug report about the CLI or a plugin.
 title: ''
 labels: bug
-assignees: ''
+assignees: 'thearchitector'
 
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,6 @@
 ## Summary
 
-Please include a summary of the change and what the PR is trying to accomplish.
-List any dependencies that are required for this change.
-
-## Changelog (optional)
-List of changes, to easily get an idea of what was done.
-
-Example:
-- Created new route `awesome_new_route_of_doom`
-- Create alembic migration for new table, `every_table_but_combined`
+Please include a summary and / or list of the changes and what the PR is trying to accomplish.
 
 ## Type of change
 
@@ -18,16 +10,3 @@ Please delete options that are not relevant.
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
-
-## Checklist:
-A quick checklist of things that should be done before the code is opened to review by others on the team.
-Delete any that are not applicable.
-
-- [ ] Jira story/task is put into PR title
-- [ ] Code has been self-reviewed
-- [ ] Hard-to-understand areas have been commented
-- [ ] Documentation has been updated
-- [ ] My changes generate no new warnings
-- [ ] Unit tests have been added for base functionality and known edge cases
-- [ ] Any dependent changes have been merged and published in downstream modules
-- [ ] Any new GraphQL routes have descriptions for variables

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-yaml
         exclude: deployment/
@@ -14,23 +14,32 @@ repos:
   #       name: isort (python)
   #       args: ["--profile", "black", "--filter-files", "--project", "virga"]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.257
+    rev: v0.0.277
     hooks:
       - id: ruff
         args: ["--fix", "--exit-non-zero-on-fix"]
-  - repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-      - id: black
-        language_version: python3.10
+  # - repo: https://github.com/psf/black
+  #   rev: 23.1.0
+  #   hooks:
+  #     - id: black
+  #       language_version: python3.10
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.4.1
     hooks:
       - id: mypy
         exclude: ^tests
         require_serial: true
-        args: ["--explicit-package-bases", "--check-untyped-defs"]
-        additional_dependencies: ["types-requests"]
+        additional_dependencies: [
+          "aiohttp[speedups]",
+          "fastapi",
+          "graphene",
+          "pydantic",
+          "pytest",
+          "sqlalchemy[mypy]~=1.4.35",
+          "typer",
+          "types-python-jose",
+          "types-requests",
+        ]
   - repo: https://github.com/matthorgan/pre-commit-conventional-commits
     rev: 20fb9631be1385998138432592d0b6d4dfa38fc9
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,30 +1,15 @@
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
-    hooks:
-      - id: check-yaml
-        exclude: deployment/
-        args: ["--allow-multiple-documents"]
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
-  # - repo: https://github.com/pycqa/isort
-  #   rev: 5.12.0
-  #   hooks:
-  #     - id: isort
-  #       name: isort (python)
-  #       args: ["--profile", "black", "--filter-files", "--project", "virga"]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.277
+    rev: v0.1.1
     hooks:
       - id: ruff
         args: ["--fix", "--exit-non-zero-on-fix"]
-  # - repo: https://github.com/psf/black
-  #   rev: 23.1.0
-  #   hooks:
-  #     - id: black
-  #       language_version: python3.10
+  - repo: https://github.com/psf/black
+    rev: 23.10.0
+    hooks:
+      - id: black
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.6.1
     hooks:
       - id: mypy
         exclude: ^tests
@@ -40,6 +25,14 @@ repos:
           "types-python-jose",
           "types-requests",
         ]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-yaml
+        exclude: deployment/
+        args: ["--allow-multiple-documents"]
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
   - repo: https://github.com/matthorgan/pre-commit-conventional-commits
     rev: 20fb9631be1385998138432592d0b6d4dfa38fc9
     hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,23 @@ ENV PATH = "${PATH}:/etc/poetry/bin"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
-    apt-get install -yf --no-install-suggests --no-install-recommends \
-        build-essential curl vim git && \
-    # node
-    curl -fsSL https://deb.nodesource.com/setup_16.x | bash && \
-    apt install --no-install-recommends -y nodejs && \
-    apt-get install -yf --no-install-suggests --no-install-recommends \
-        nodejs npm && \
-    npm install -g yarn && \
-    # helm
+    apt-get install -y --no-install-suggests --no-install-recommends \
+        ca-certificates curl gnupg build-essential curl vim git
+
+# node
+RUN mkdir -p /etc/apt/keyrings && \
     curl -fsSL \
+        https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg \
+            --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | tee \
+        /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    apt-get install -y --no-install-suggests --no-install-recommends \
+        nodejs npm && \
+    npm install -g yarn
+
+# helm
+RUN curl -fsSL \
         https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,13 @@ ENV PATH = "${PATH}:/etc/poetry/bin"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y build-essential curl vim git && \
+    apt-get install -yf --no-install-suggests --no-install-recommends \
+        build-essential curl vim git && \
     # node
     curl -fsSL https://deb.nodesource.com/setup_16.x | bash && \
     apt install --no-install-recommends -y nodejs && \
+    apt-get install -yf --no-install-suggests --no-install-recommends \
+        nodejs npm && \
     npm install -g yarn && \
     # helm
     curl -fsSL \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ WORKDIR /virga
 # python dependencies (Poetry)
 RUN curl -sSL https://install.python-poetry.org | python3 - && \
     poetry config virtualenvs.create false && \
-    poetry install --extras "cli auth database graphql testing"
+    poetry install --all-extras
 
 CMD [ "bash" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,7 +28,8 @@ services:
 
   virga:
     build: .
-    command: /virga/scripts/run_tests.sh
+    # command: /virga/scripts/run_tests.sh
+    command: sleep inf
     environment:
       POSTGRES_HOST: test-db
       POSTGRES_DB: indico

--- a/poetry.lock
+++ b/poetry.lock
@@ -143,14 +143,12 @@ files = [
 aiodns = {version = "*", optional = true, markers = "extra == \"speedups\""}
 aiosignal = ">=1.1.2"
 async-timeout = ">=4.0.0a3,<5.0"
-asynctest = {version = "0.13.0", markers = "python_version < \"3.8\""}
 attrs = ">=17.3.0"
 Brotli = {version = "*", optional = true, markers = "extra == \"speedups\""}
 cchardet = {version = "*", optional = true, markers = "python_version < \"3.10\" and extra == \"speedups\""}
 charset-normalizer = ">=2.0,<4.0"
 frozenlist = ">=1.1.1"
 multidict = ">=4.5,<7.0"
-typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 yarl = ">=1.0,<2.0"
 
 [package.extras]
@@ -217,9 +215,6 @@ files = [
     {file = "async_timeout-4.0.2-py3-none-any.whl", hash = "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=3.6.5", markers = "python_version < \"3.8\""}
-
 [[package]]
 name = "asyncpg"
 version = "0.25.0"
@@ -256,25 +251,10 @@ files = [
     {file = "asyncpg-0.25.0.tar.gz", hash = "sha256:63f8e6a69733b285497c2855464a34de657f2cccd25aeaeeb5071872e9382540"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""}
-
 [package.extras]
 dev = ["Cython (>=0.29.24,<0.30.0)", "Sphinx (>=4.1.2,<4.2.0)", "flake8 (>=3.9.2,<3.10.0)", "pycodestyle (>=2.7.0,<2.8.0)", "pytest (>=6.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)", "uvloop (>=0.15.3)"]
 docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)"]
 test = ["flake8 (>=3.9.2,<3.10.0)", "pycodestyle (>=2.7.0,<2.8.0)", "uvloop (>=0.15.3)"]
-
-[[package]]
-name = "asynctest"
-version = "0.13.0"
-description = "Enhance the standard unittest package with features for testing asyncio libraries"
-category = "main"
-optional = true
-python-versions = ">=3.5"
-files = [
-    {file = "asynctest-0.13.0-py3-none-any.whl", hash = "sha256:5da6118a7e6d6b54d83a8f7197769d046922a44d2a99c21382f0a6e4fadae676"},
-    {file = "asynctest-0.13.0.tar.gz", hash = "sha256:c27862842d15d83e6a34eb0b2866c323880eb3a75e4485b079ea11748fd77fac"},
-]
 
 [[package]]
 name = "atomicwrites"
@@ -298,9 +278,6 @@ files = [
     {file = "attrs-23.1.0-py3-none-any.whl", hash = "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"},
     {file = "attrs-23.1.0.tar.gz", hash = "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"},
 ]
-
-[package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
@@ -628,7 +605,6 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
@@ -961,7 +937,7 @@ name = "importlib-metadata"
 version = "6.6.0"
 description = "Read metadata from Python packages"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "importlib_metadata-6.6.0-py3-none-any.whl", hash = "sha256:43dd286a2cd8995d5eaef7fee2066340423b818ed3fd70adf0bad5f1fac53fed"},
@@ -969,7 +945,6 @@ files = [
 ]
 
 [package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
@@ -1021,7 +996,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 MarkupSafe = ">=0.9.2"
 
 [package.extras]
@@ -1043,7 +1017,6 @@ files = [
 
 [package.dependencies]
 mdurl = ">=0.1,<1.0"
-typing_extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 benchmarking = ["psutil", "pytest", "pytest-benchmark"]
@@ -1302,9 +1275,6 @@ files = [
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
@@ -1514,7 +1484,6 @@ files = [
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
@@ -1539,7 +1508,6 @@ files = [
 
 [package.dependencies]
 pytest = ">=6.1.0"
-typing-extensions = {version = ">=3.7.2", markers = "python_version < \"3.8\""}
 
 [package.extras]
 testing = ["coverage (==6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (==0.931)", "pytest-trio (>=0.7.0)"]
@@ -1700,7 +1668,6 @@ files = [
 
 [package.dependencies]
 greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\" and platform_machine == \"aarch64\" or python_version >= \"3\" and platform_machine == \"ppc64le\" or python_version >= \"3\" and platform_machine == \"x86_64\" or python_version >= \"3\" and platform_machine == \"amd64\" or python_version >= \"3\" and platform_machine == \"AMD64\" or python_version >= \"3\" and platform_machine == \"win32\" or python_version >= \"3\" and platform_machine == \"WIN32\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 aiomysql = ["aiomysql", "greenlet (!=0.4.17)"]
@@ -1889,14 +1856,13 @@ files = [
 [package.dependencies]
 idna = ">=2.0"
 multidict = ">=4.0"
-typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "zipp"
 version = "3.15.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"},
@@ -1916,5 +1882,5 @@ testing = ["pytest", "requests"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.7"
-content-hash = "b1c57ae7a9eda0d2b28ca4b37cbbef90fdea8cde31d6b62d66d9e75f7f60f42d"
+python-versions = "^3.8"
+content-hash = "5ea6aa878b4194e36d05af3e556a78b382869bd8f5de1def444684aa144eedfd"

--- a/poetry.lock
+++ b/poetry.lock
@@ -173,14 +173,14 @@ frozenlist = ">=1.1.0"
 
 [[package]]
 name = "alembic"
-version = "1.10.2"
+version = "1.11.1"
 description = "A database migration tool for SQLAlchemy."
 category = "main"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "alembic-1.10.2-py3-none-any.whl", hash = "sha256:8b48368f6533c064b39c024e1daba15ae7f947eac84185c28c06bbe1301a5497"},
-    {file = "alembic-1.10.2.tar.gz", hash = "sha256:457eafbdc0769d855c2c92cbafe6b7f319f916c80cf4ed02b8f394f38b51b89d"},
+    {file = "alembic-1.11.1-py3-none-any.whl", hash = "sha256:dc871798a601fab38332e38d6ddb38d5e734f60034baeb8e2db5b642fccd8ab8"},
+    {file = "alembic-1.11.1.tar.gz", hash = "sha256:6a810a6b012c88b33458fceb869aef09ac75d6ace5291915ba7fae44de372c01"},
 ]
 
 [package.dependencies]
@@ -289,22 +289,25 @@ files = [
 
 [[package]]
 name = "attrs"
-version = "22.2.0"
+version = "23.1.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "attrs-22.2.0-py3-none-any.whl", hash = "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836"},
-    {file = "attrs-22.2.0.tar.gz", hash = "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"},
+    {file = "attrs-23.1.0-py3-none-any.whl", hash = "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"},
+    {file = "attrs-23.1.0.tar.gz", hash = "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"},
 ]
 
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
 [package.extras]
-cov = ["attrs[tests]", "coverage-enable-subprocess", "coverage[toml] (>=5.3)"]
-dev = ["attrs[docs,tests]"]
-docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope.interface"]
-tests = ["attrs[tests-no-zope]", "zope.interface"]
-tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy (>=0.971,<0.990)", "mypy (>=0.971,<0.990)", "pympler", "pympler", "pytest (>=4.3.0)", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-mypy-plugins", "pytest-xdist[psutil]", "pytest-xdist[psutil]"]
+cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
+dev = ["attrs[docs,tests]", "pre-commit"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
+tests = ["attrs[tests-no-zope]", "zope-interface"]
+tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 
 [[package]]
 name = "brotli"
@@ -439,14 +442,14 @@ files = [
 
 [[package]]
 name = "certifi"
-version = "2022.12.7"
+version = "2023.5.7"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
-    {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
+    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
+    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
 ]
 
 [[package]]
@@ -613,14 +616,14 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.1.0"
+version = "8.1.3"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "click-8.1.0-py3-none-any.whl", hash = "sha256:19a4baa64da924c5e0cd889aba8e947f280309f1a2ce0947a3e3a7bcb7cc72d6"},
-    {file = "click-8.1.0.tar.gz", hash = "sha256:977c213473c7665d3aa092b41ff12063227751c41d7b17165013e10069cc5cd2"},
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 
 [package.dependencies]
@@ -641,35 +644,31 @@ files = [
 
 [[package]]
 name = "cryptography"
-version = "39.0.2"
+version = "41.0.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "cryptography-39.0.2-cp36-abi3-macosx_10_12_universal2.whl", hash = "sha256:2725672bb53bb92dc7b4150d233cd4b8c59615cd8288d495eaa86db00d4e5c06"},
-    {file = "cryptography-39.0.2-cp36-abi3-macosx_10_12_x86_64.whl", hash = "sha256:23df8ca3f24699167daf3e23e51f7ba7334d504af63a94af468f468b975b7dd7"},
-    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:eb40fe69cfc6f5cdab9a5ebd022131ba21453cf7b8a7fd3631f45bbf52bed612"},
-    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc0521cce2c1d541634b19f3ac661d7a64f9555135e9d8af3980965be717fd4a"},
-    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffd394c7896ed7821a6d13b24657c6a34b6e2650bd84ae063cf11ccffa4f1a97"},
-    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:e8a0772016feeb106efd28d4a328e77dc2edae84dfbac06061319fdb669ff828"},
-    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8f35c17bd4faed2bc7797d2a66cbb4f986242ce2e30340ab832e5d99ae60e011"},
-    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b49a88ff802e1993b7f749b1eeb31134f03c8d5c956e3c125c75558955cda536"},
-    {file = "cryptography-39.0.2-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:5f8c682e736513db7d04349b4f6693690170f95aac449c56f97415c6980edef5"},
-    {file = "cryptography-39.0.2-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:d7d84a512a59f4412ca8549b01f94be4161c94efc598bf09d027d67826beddc0"},
-    {file = "cryptography-39.0.2-cp36-abi3-win32.whl", hash = "sha256:c43ac224aabcbf83a947eeb8b17eaf1547bce3767ee2d70093b461f31729a480"},
-    {file = "cryptography-39.0.2-cp36-abi3-win_amd64.whl", hash = "sha256:788b3921d763ee35dfdb04248d0e3de11e3ca8eb22e2e48fef880c42e1f3c8f9"},
-    {file = "cryptography-39.0.2-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:d15809e0dbdad486f4ad0979753518f47980020b7a34e9fc56e8be4f60702fac"},
-    {file = "cryptography-39.0.2-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:50cadb9b2f961757e712a9737ef33d89b8190c3ea34d0fb6675e00edbe35d074"},
-    {file = "cryptography-39.0.2-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:103e8f7155f3ce2ffa0049fe60169878d47a4364b277906386f8de21c9234aa1"},
-    {file = "cryptography-39.0.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:6236a9610c912b129610eb1a274bdc1350b5df834d124fa84729ebeaf7da42c3"},
-    {file = "cryptography-39.0.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e944fe07b6f229f4c1a06a7ef906a19652bdd9fd54c761b0ff87e83ae7a30354"},
-    {file = "cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:35d658536b0a4117c885728d1a7032bdc9a5974722ae298d6c533755a6ee3915"},
-    {file = "cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:30b1d1bfd00f6fc80d11300a29f1d8ab2b8d9febb6ed4a38a76880ec564fae84"},
-    {file = "cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:e029b844c21116564b8b61216befabca4b500e6816fa9f0ba49527653cae2108"},
-    {file = "cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fa507318e427169ade4e9eccef39e9011cdc19534f55ca2f36ec3f388c1f70f3"},
-    {file = "cryptography-39.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:8bc0008ef798231fac03fe7d26e82d601d15bd16f3afaad1c6113771566570f3"},
-    {file = "cryptography-39.0.2.tar.gz", hash = "sha256:bc5b871e977c8ee5a1bbc42fa8d19bcc08baf0c51cbf1586b0e87a2694dde42f"},
+    {file = "cryptography-41.0.1-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:f73bff05db2a3e5974a6fd248af2566134d8981fd7ab012e5dd4ddb1d9a70699"},
+    {file = "cryptography-41.0.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:1a5472d40c8f8e91ff7a3d8ac6dfa363d8e3138b961529c996f3e2df0c7a411a"},
+    {file = "cryptography-41.0.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fa01527046ca5facdf973eef2535a27fec4cb651e4daec4d043ef63f6ecd4ca"},
+    {file = "cryptography-41.0.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b46e37db3cc267b4dea1f56da7346c9727e1209aa98487179ee8ebed09d21e43"},
+    {file = "cryptography-41.0.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d198820aba55660b4d74f7b5fd1f17db3aa5eb3e6893b0a41b75e84e4f9e0e4b"},
+    {file = "cryptography-41.0.1-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:948224d76c4b6457349d47c0c98657557f429b4e93057cf5a2f71d603e2fc3a3"},
+    {file = "cryptography-41.0.1-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:059e348f9a3c1950937e1b5d7ba1f8e968508ab181e75fc32b879452f08356db"},
+    {file = "cryptography-41.0.1-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:b4ceb5324b998ce2003bc17d519080b4ec8d5b7b70794cbd2836101406a9be31"},
+    {file = "cryptography-41.0.1-cp37-abi3-win32.whl", hash = "sha256:8f4ab7021127a9b4323537300a2acfb450124b2def3756f64dc3a3d2160ee4b5"},
+    {file = "cryptography-41.0.1-cp37-abi3-win_amd64.whl", hash = "sha256:1fee5aacc7367487b4e22484d3c7e547992ed726d14864ee33c0176ae43b0d7c"},
+    {file = "cryptography-41.0.1-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9a6c7a3c87d595608a39980ebaa04d5a37f94024c9f24eb7d10262b92f739ddb"},
+    {file = "cryptography-41.0.1-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5d092fdfedaec4cbbffbf98cddc915ba145313a6fdaab83c6e67f4e6c218e6f3"},
+    {file = "cryptography-41.0.1-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:1a8e6c2de6fbbcc5e14fd27fb24414507cb3333198ea9ab1258d916f00bc3039"},
+    {file = "cryptography-41.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:cb33ccf15e89f7ed89b235cff9d49e2e62c6c981a6061c9c8bb47ed7951190bc"},
+    {file = "cryptography-41.0.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5f0ff6e18d13a3de56f609dd1fd11470918f770c6bd5d00d632076c727d35485"},
+    {file = "cryptography-41.0.1-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:7bfc55a5eae8b86a287747053140ba221afc65eb06207bedf6e019b8934b477c"},
+    {file = "cryptography-41.0.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:eb8163f5e549a22888c18b0d53d6bb62a20510060a22fd5a995ec8a05268df8a"},
+    {file = "cryptography-41.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:8dde71c4169ec5ccc1087bb7521d54251c016f126f922ab2dfe6649170a3b8c5"},
+    {file = "cryptography-41.0.1.tar.gz", hash = "sha256:d34579085401d3f49762d2f7d6634d6b6c2ae1242202e860f4d26b046e3a1006"},
 ]
 
 [package.dependencies]
@@ -678,12 +677,12 @@ cffi = ">=1.12"
 [package.extras]
 docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
 docstest = ["pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
-pep8test = ["black", "check-manifest", "mypy", "ruff", "types-pytz", "types-requests"]
-sdist = ["setuptools-rust (>=0.11.4)"]
+nox = ["nox"]
+pep8test = ["black", "check-sdist", "mypy", "ruff"]
+sdist = ["build"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-shard (>=0.1.2)", "pytest-subtests", "pytest-xdist", "pytz"]
+test = ["pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
 test-randomorder = ["pytest-randomly"]
-tox = ["tox"]
 
 [[package]]
 name = "ecdsa"
@@ -959,14 +958,14 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "6.1.0"
+version = "6.6.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "importlib_metadata-6.1.0-py3-none-any.whl", hash = "sha256:ff80f3b5394912eb1b108fcfd444dc78b7f1f3e16b16188054bd01cb9cb86f09"},
-    {file = "importlib_metadata-6.1.0.tar.gz", hash = "sha256:43ce9281e097583d758c2c708c4376371261a02c34682491a8e98352365aad20"},
+    {file = "importlib_metadata-6.6.0-py3-none-any.whl", hash = "sha256:43dd286a2cd8995d5eaef7fee2066340423b818ed3fd70adf0bad5f1fac53fed"},
+    {file = "importlib_metadata-6.6.0.tar.gz", hash = "sha256:92501cdf9cc66ebd3e612f1b4f0c0765dfa42f0fa38ffb319b6bd84dd675d705"},
 ]
 
 [package.dependencies]
@@ -1031,6 +1030,32 @@ lingua = ["lingua"]
 testing = ["pytest"]
 
 [[package]]
+name = "markdown-it-py"
+version = "2.2.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "markdown-it-py-2.2.0.tar.gz", hash = "sha256:7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1"},
+    {file = "markdown_it_py-2.2.0-py3-none-any.whl", hash = "sha256:5a35f8d1870171d9acc47b99612dc146129b631baf04970128b568f190d0cc30"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+typing_extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins"]
+profiling = ["gprof2dot"]
+rtd = ["attrs", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
 name = "markupsafe"
 version = "2.1.2"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -1088,6 +1113,18 @@ files = [
     {file = "MarkupSafe-2.1.2-cp39-cp39-win32.whl", hash = "sha256:137678c63c977754abe9086a3ec011e8fd985ab90631145dfb9294ad09c102a7"},
     {file = "MarkupSafe-2.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:0576fe974b40a400449768941d5d0858cc624e3249dfd1e0c33674e5c7ca7aed"},
     {file = "MarkupSafe-2.1.2.tar.gz", hash = "sha256:abcabc8c2b26036d62d4c746381a6f7cf60aafcc653198ad678306986b09450d"},
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
 
 [[package]]
@@ -1176,73 +1213,70 @@ files = [
 
 [[package]]
 name = "orjson"
-version = "3.8.8"
+version = "3.9.0"
 description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "orjson-3.8.8-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:18fcdea75d8b571dc9b185652b81397b62878ae7934fd62e6a0103a5b8448e34"},
-    {file = "orjson-3.8.8-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:306618884929b596e2e083f82b5617da812df25b0c467542371f1d51f0c5a6f5"},
-    {file = "orjson-3.8.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edc65ddb6ae6f8fbb2bbf78ac98f75b729c9eeb0776d5508dd76d3a948dda1dd"},
-    {file = "orjson-3.8.8-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e6a6d55e01bce74516dff15302627a13b1f4edcb1c3942dd660978dee423ccf2"},
-    {file = "orjson-3.8.8-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:28075c4b502d792fb6703e983d456b2a30d5d6f332d26092eb312dc782e64c64"},
-    {file = "orjson-3.8.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eda4c37e48ff549763183a1549c10eec6ea40439520b17d09359cd74a425069"},
-    {file = "orjson-3.8.8-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a3eac485a15493164867729f44e1e1247b3094ff19d37708e8cdc9c88a93c623"},
-    {file = "orjson-3.8.8-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:88bf40e5468444c04374d1b8f1877cebbaef6bb7406cb6b4a34a570c5cbb87bc"},
-    {file = "orjson-3.8.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:747bd4e09d8aa61e1ff677a7dd1cffd28a5d13c22f3769123c58ec988bf1b83d"},
-    {file = "orjson-3.8.8-cp310-none-win_amd64.whl", hash = "sha256:dd7d86c5f5f820ac9d4783477e86eb984b63bdb32359935609eb33cf65049c54"},
-    {file = "orjson-3.8.8-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:52293a6097750c2d434737966fe6e2a1ed489ac70cc8e584f5944af83de0b787"},
-    {file = "orjson-3.8.8-cp311-cp311-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:9322450f392dceb49810d2f820b1932af22d66f67f1d45c31f160067dd06359f"},
-    {file = "orjson-3.8.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68d59e3ae84a9b6f14b45a89f7fde4a08a87ea5eb76bfc854b354640de8156f5"},
-    {file = "orjson-3.8.8-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:022347dad2253081eaa25366834bb8b06a5aceb0e83b39c6b0aa865759e49d69"},
-    {file = "orjson-3.8.8-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ddfcc54793e266056fe1c257d0804c336bca1c5c1ee7979d674e1fc19cfb0a6a"},
-    {file = "orjson-3.8.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:449d8ed1e0e6b24e9df5a06b59fd66ea7f7293e141257069601ae8ff9fad705c"},
-    {file = "orjson-3.8.8-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:0204bc414bc6f7a595211569840b422d96649fd8686efa1fbbcb12eed5dd9521"},
-    {file = "orjson-3.8.8-cp311-none-win_amd64.whl", hash = "sha256:e991a5c2c5f2f299c77e1d07ef2812ff5b68e1d97a2aab01aca29cf756473aa3"},
-    {file = "orjson-3.8.8-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:2006d9c046bbf335c951f61e016a27bd4f17323dd116f601e4a8a11739cd0a62"},
-    {file = "orjson-3.8.8-cp37-cp37m-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:4553d85bad4cbd634a40b7b5d36daaa197a6025f9ce3e2165b371e528759093d"},
-    {file = "orjson-3.8.8-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57ee45d2cc6c11c50afb5a0c09d7cd559aea76c77250dbe996be6a03464d4a50"},
-    {file = "orjson-3.8.8-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:02f5b5db1e424706eb9f70f1c25699ff4cef16fadfc64af5b70f8628eafe4771"},
-    {file = "orjson-3.8.8-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d7c9f3b1598a1ccd806ef02257a76a00c7ede09662ddb54eec2b4bd92874254"},
-    {file = "orjson-3.8.8-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b90d171932b6a9d50e79fa2762cb303e3556bbf25c08bb316fe346ec58af9c19"},
-    {file = "orjson-3.8.8-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:28dfe774c345130f1117c4d023644ec52d9d50e3eaadb9bd1c668d91dc109bb5"},
-    {file = "orjson-3.8.8-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:8f84116fcc3714e7ba3cbeb1b11ac5e4549e7d2726c50142f8299fff9dea7d53"},
-    {file = "orjson-3.8.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:f989f8580db86166aaaa938ccd1597ba1817e3f5df14c047baafe783e3d24173"},
-    {file = "orjson-3.8.8-cp37-none-win_amd64.whl", hash = "sha256:66045850f286090800a18662d81d44f88c3fcb60ea3a9947d5caeab5d1efc92e"},
-    {file = "orjson-3.8.8-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:2c2c5f3d3bbd61dba646e2b9c54a0dd7941b03fba49726bd31c1c23fedf0b9aa"},
-    {file = "orjson-3.8.8-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:9cb36d4a14f3a911369219d5abc19b907bc41ed2730f7bfe0847b0fd3e834c87"},
-    {file = "orjson-3.8.8-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:343124f84da0a33c83ee106a98b3e3c42767c88323d4a2809683cbe83816e8be"},
-    {file = "orjson-3.8.8-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24ad122d8dd057acf2a9965a2ffc1bc12fb310ae1cfe2912db930cbb9ef7eaba"},
-    {file = "orjson-3.8.8-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c2f28a92a9bcb4e8635524b20db1b539bda8613872f306b36cdfd9d3577d03ac"},
-    {file = "orjson-3.8.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81d3c5b253eebfc4a61cea1f255a576cb2b889afa99f4510f30ec13201d4f457"},
-    {file = "orjson-3.8.8-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:317164f7d4c0540a6eb8b0a0faeec84ef011d359da05188423db762b65f84e1d"},
-    {file = "orjson-3.8.8-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:5e7e39357371d4ae5649f33c01886508a4c8e5fa5c7344554af041dc0f004c01"},
-    {file = "orjson-3.8.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:60fefd4bbd796b4296f478e705fe2c2c7defd28da98d3017743eb87c3238a380"},
-    {file = "orjson-3.8.8-cp38-none-win_amd64.whl", hash = "sha256:0dc4a52f1087baeec6b58248fd6b01f17c124fb99f6f770596851ea434a7be0b"},
-    {file = "orjson-3.8.8-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:a6bcb449537a99f55c5f05187bac00b4549a795e89c10dcca0d7629548852357"},
-    {file = "orjson-3.8.8-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:9c98dc791aa44268ba7f6e21124cf885c813b155316c6bf257560571d243fe15"},
-    {file = "orjson-3.8.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b2abf93b727a6af7c5ec8816168cbdff39c716af18ced425dd50ae46d69765c"},
-    {file = "orjson-3.8.8-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:23447d38375a19d57975d4e32d9ce9f533803c197fd4292e10d3234c052037a8"},
-    {file = "orjson-3.8.8-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4c2e19d2b46cc93c7218bf8180807bf922ff61dc9883458a06edc66d22970fff"},
-    {file = "orjson-3.8.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e480d74d7bf415e6548a364669404119a85dbe0e3c6cd5f7cb4c7003eac20164"},
-    {file = "orjson-3.8.8-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:8e0bff5656b99dd975cae2e5230b39e5909d06c0692fd1f6f06dc46f1fe705d0"},
-    {file = "orjson-3.8.8-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:56bb6eb7a254eec3b15feba9b20f4172ccbe6ea50a54cf66cbc8e1e4a19585c2"},
-    {file = "orjson-3.8.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:1af1cfad5d90b68e15fd625c889c4f9f91d7a88f49512cdb89f01c3881e0c9d9"},
-    {file = "orjson-3.8.8-cp39-none-win_amd64.whl", hash = "sha256:d5514dfe200356a1d5a6039e00dca78d87d063f3da1eb6a371253e5a8b7ab5b0"},
-    {file = "orjson-3.8.8.tar.gz", hash = "sha256:c096d7a523bae6ffb9c4a228ba4691d66113f0f2231579dc945523fbef09c6da"},
+    {file = "orjson-3.9.0-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:128b1cd0f00a37ba64a12cceeba4e8070655d4400edd55a737513ee663c1ed5a"},
+    {file = "orjson-3.9.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a3693fde44b2eeb80074ecbe8c504b25baf71e66c080af2a574193a5ba81960"},
+    {file = "orjson-3.9.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3f1193417b5a93deb41bcb8db27b61179b9b3e299b337b578c31f19159664da3"},
+    {file = "orjson-3.9.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:88626d898c408450c57664899831cf072787898af4847fa4466607ad2a83f454"},
+    {file = "orjson-3.9.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e3bde77c1e0061eb34bae6fea44818b2198e043ee10a16ad7b160921fee26ea"},
+    {file = "orjson-3.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45df5bf6531ffda518331cc93cdcd4c84f4a4a0507d72af8fb698c7131a440a0"},
+    {file = "orjson-3.9.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2536a7f30fd4d77532769ea9285cd20c69bd2b40acf980de94bbc79b1c6fad5a"},
+    {file = "orjson-3.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:21f6a6fdfbc13cd715c61e9fa9daeff732df6401ab7d6a2ebad0042313a40bd1"},
+    {file = "orjson-3.9.0-cp310-none-win_amd64.whl", hash = "sha256:46c9733330b75c116438f555c0b971a2388b5f502e2dd4ec3bf6bacb96f82741"},
+    {file = "orjson-3.9.0-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:47d7e4a3effc0e9314bd5b06e7431f2490a5e64dcdcbbc4d60e713786fec327d"},
+    {file = "orjson-3.9.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c41d1ef6ec308e9e3701764b3de889ed8c1c126eceaea881dd1027bffbed89fe"},
+    {file = "orjson-3.9.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:86da00836029b2a071229c8aecab998a2f316c1bc7de10ae020d7311de3a6d0d"},
+    {file = "orjson-3.9.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d4fcf598bd5a99a94caa7ec92ce657939f12491e4753ea7e4d6c03faf5f7912e"},
+    {file = "orjson-3.9.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:09522937479bd39d5bb32d11a5ecdf6926fda43ac2cbde21cc1a9508b4e4ea29"},
+    {file = "orjson-3.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2fbf34667a8be48ec89d5ef479a00d4e7b3acda62d722c97377702da0c30ffd"},
+    {file = "orjson-3.9.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:edd77183c154cbedaa6dac32fee9cb770b04e2a7f367a5864f444578554cc946"},
+    {file = "orjson-3.9.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2af7dff1c7ddb0c83eb5773acf6566b153f8cd32e4ba782ae9ccd6d0f324efd3"},
+    {file = "orjson-3.9.0-cp311-none-win_amd64.whl", hash = "sha256:44fa74b497e608a8cdca1ee37fe3533a30f17163c7e2872ab1b854900cf0dfcf"},
+    {file = "orjson-3.9.0-cp37-cp37m-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:f6476e2487c0b7387187de15e5b8f6635c29b75934f2e689ca8cad6550439f3d"},
+    {file = "orjson-3.9.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c7b241c3229084035b38cac9b5c96b43644da829da41d9d5be0fefb96fb116e1"},
+    {file = "orjson-3.9.0-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d414fd0678e949779104f5b307f0f9fac861728e19d3cdde66759af77f892da0"},
+    {file = "orjson-3.9.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8a1fcddcabe121e393f3c4a31ed6d3535214d42a4ece0f9dde2e250006d6a58d"},
+    {file = "orjson-3.9.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd89d63707ac616462832bfc5d16fa0c12483f86add2432ce55c8710c9531c03"},
+    {file = "orjson-3.9.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c50654e4870805e4b1a587c2c3c5ef2f36f3e67fc463a738339ff40d65f7db1"},
+    {file = "orjson-3.9.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:721d47dffedb7795ffea8a06f2de7d192de7b58e085cf357a99abf0eb931f2c3"},
+    {file = "orjson-3.9.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:9de2129d40674007cb24164939e075b5b39fee768bf20801e08c0e3283bfb18e"},
+    {file = "orjson-3.9.0-cp37-none-win_amd64.whl", hash = "sha256:5afd22847b07b63f2b8fcfddd5b7a6f47c5aaa25e19b97a3d6d39508b8fd465a"},
+    {file = "orjson-3.9.0-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:d4c2d31178e3027affd98eead033f1c406890df83a0ca2016604cc21f722a1d1"},
+    {file = "orjson-3.9.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebe372e9f4e4f0335b7b4ebfab991b3734371e3d5b7f989ca3baa5da25185f4a"},
+    {file = "orjson-3.9.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c4949fc1304b702197c0840882e84b86d8d5ca33c3d945cc60727bc1786c2b20"},
+    {file = "orjson-3.9.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:748c1e8df0b0880c63d323e167ad17ab4db2e1178a40902c2fcb68cbe402d7c8"},
+    {file = "orjson-3.9.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f6ab80b60195f166a9d666b2eaf6d2c74202b6da2a1fb4b4d66b9cc0ce5c9957"},
+    {file = "orjson-3.9.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e44ebe2129d43c5a48f3affa3fa59c6484ed16faf5b00486add1061a95384ab0"},
+    {file = "orjson-3.9.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:04e61db09ff155846b69d07cf5aa21001f2010ea669ec3169c1fbad9c9e40cd5"},
+    {file = "orjson-3.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c68af71b1110820c914f9df75842895b5528ff524d3286fde57097b2b5ed8f22"},
+    {file = "orjson-3.9.0-cp38-none-win_amd64.whl", hash = "sha256:3a208d0bca609de3152eb8320d5093ad9c52979332f626c13500d1645c66bf8d"},
+    {file = "orjson-3.9.0-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:a901c432828c191332d75f358142736c433d4a192f7794123e1d30d68193de86"},
+    {file = "orjson-3.9.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:271b6f1018757fc6bca40ae72e6cdb6cf84584dde2d1e5eaac30e387a13d9e72"},
+    {file = "orjson-3.9.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:949698bdddb1daff986d73e6bbe6cd68833cd80c4adc6b69fafbd46634d4672c"},
+    {file = "orjson-3.9.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:108c58d2c7648c991f82f9b2217c50981ad7cf6aaee3efbfaa9d807e49cd69b8"},
+    {file = "orjson-3.9.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08cb43569198c1f5c89ecafcbfc62414f6115d894ff908d8cf8e5e24801364e6"},
+    {file = "orjson-3.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09ee828572fadcd58bf356d2c1bad99a95c7c9c1f182b407abbc7dec1810f542"},
+    {file = "orjson-3.9.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0e7fe5d603ee9177ff2e45858b4fc47fea2da0688f23d9773654889d56dfbc82"},
+    {file = "orjson-3.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9ee5f1ba82146a50d61fb58d310a37c0f406eda898172f9c98673b5d6f9461c3"},
+    {file = "orjson-3.9.0-cp39-none-win_amd64.whl", hash = "sha256:3235c31d0fe674f6e3433e9ddfed212aa840c83a9b6ef5ae128950e2c808c303"},
+    {file = "orjson-3.9.0.tar.gz", hash = "sha256:f6dd27c71cd6e146795f876449a8eae74f67ae1e4e244dfc1203489103eb2d94"},
 ]
 
 [[package]]
 name = "packaging"
-version = "23.0"
+version = "23.1"
 description = "Core utilities for Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "packaging-23.0-py3-none-any.whl", hash = "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"},
-    {file = "packaging-23.0.tar.gz", hash = "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"},
+    {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
+    {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
 ]
 
 [[package]]
@@ -1306,14 +1340,14 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.4.8"
-description = "ASN.1 types and codecs"
+version = "0.5.0"
+description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 category = "main"
 optional = true
-python-versions = "*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 files = [
-    {file = "pyasn1-0.4.8-py2.py3-none-any.whl", hash = "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d"},
-    {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
+    {file = "pyasn1-0.5.0-py2.py3-none-any.whl", hash = "sha256:87a2121042a1ac9358cabcaf1d07680ff97ee6404333bacca15f76aa8ad01a57"},
+    {file = "pyasn1-0.5.0.tar.gz", hash = "sha256:97b7290ca68e62a832558ec3976f15cbf911bf5d7c7039d8b861c2a0ece69fde"},
 ]
 
 [[package]]
@@ -1398,48 +1432,48 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "1.10.6"
+version = "1.10.8"
 description = "Data validation and settings management using python type hints"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pydantic-1.10.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f9289065611c48147c1dd1fd344e9d57ab45f1d99b0fb26c51f1cf72cd9bcd31"},
-    {file = "pydantic-1.10.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8c32b6bba301490d9bb2bf5f631907803135e8085b6aa3e5fe5a770d46dd0160"},
-    {file = "pydantic-1.10.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd9b9e98068fa1068edfc9eabde70a7132017bdd4f362f8b4fd0abed79c33083"},
-    {file = "pydantic-1.10.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1c84583b9df62522829cbc46e2b22e0ec11445625b5acd70c5681ce09c9b11c4"},
-    {file = "pydantic-1.10.6-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:b41822064585fea56d0116aa431fbd5137ce69dfe837b599e310034171996084"},
-    {file = "pydantic-1.10.6-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:61f1f08adfaa9cc02e0cbc94f478140385cbd52d5b3c5a657c2fceb15de8d1fb"},
-    {file = "pydantic-1.10.6-cp310-cp310-win_amd64.whl", hash = "sha256:32937835e525d92c98a1512218db4eed9ddc8f4ee2a78382d77f54341972c0e7"},
-    {file = "pydantic-1.10.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bbd5c531b22928e63d0cb1868dee76123456e1de2f1cb45879e9e7a3f3f1779b"},
-    {file = "pydantic-1.10.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e277bd18339177daa62a294256869bbe84df1fb592be2716ec62627bb8d7c81d"},
-    {file = "pydantic-1.10.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89f15277d720aa57e173954d237628a8d304896364b9de745dcb722f584812c7"},
-    {file = "pydantic-1.10.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b243b564cea2576725e77aeeda54e3e0229a168bc587d536cd69941e6797543d"},
-    {file = "pydantic-1.10.6-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:3ce13a558b484c9ae48a6a7c184b1ba0e5588c5525482681db418268e5f86186"},
-    {file = "pydantic-1.10.6-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3ac1cd4deed871dfe0c5f63721e29debf03e2deefa41b3ed5eb5f5df287c7b70"},
-    {file = "pydantic-1.10.6-cp311-cp311-win_amd64.whl", hash = "sha256:b1eb6610330a1dfba9ce142ada792f26bbef1255b75f538196a39e9e90388bf4"},
-    {file = "pydantic-1.10.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4ca83739c1263a044ec8b79df4eefc34bbac87191f0a513d00dd47d46e307a65"},
-    {file = "pydantic-1.10.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea4e2a7cb409951988e79a469f609bba998a576e6d7b9791ae5d1e0619e1c0f2"},
-    {file = "pydantic-1.10.6-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:53de12b4608290992a943801d7756f18a37b7aee284b9ffa794ee8ea8153f8e2"},
-    {file = "pydantic-1.10.6-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:60184e80aac3b56933c71c48d6181e630b0fbc61ae455a63322a66a23c14731a"},
-    {file = "pydantic-1.10.6-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:415a3f719ce518e95a92effc7ee30118a25c3d032455d13e121e3840985f2efd"},
-    {file = "pydantic-1.10.6-cp37-cp37m-win_amd64.whl", hash = "sha256:72cb30894a34d3a7ab6d959b45a70abac8a2a93b6480fc5a7bfbd9c935bdc4fb"},
-    {file = "pydantic-1.10.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3091d2eaeda25391405e36c2fc2ed102b48bac4b384d42b2267310abae350ca6"},
-    {file = "pydantic-1.10.6-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:751f008cd2afe812a781fd6aa2fb66c620ca2e1a13b6a2152b1ad51553cb4b77"},
-    {file = "pydantic-1.10.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:12e837fd320dd30bd625be1b101e3b62edc096a49835392dcf418f1a5ac2b832"},
-    {file = "pydantic-1.10.6-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:587d92831d0115874d766b1f5fddcdde0c5b6c60f8c6111a394078ec227fca6d"},
-    {file = "pydantic-1.10.6-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:476f6674303ae7965730a382a8e8d7fae18b8004b7b69a56c3d8fa93968aa21c"},
-    {file = "pydantic-1.10.6-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:3a2be0a0f32c83265fd71a45027201e1278beaa82ea88ea5b345eea6afa9ac7f"},
-    {file = "pydantic-1.10.6-cp38-cp38-win_amd64.whl", hash = "sha256:0abd9c60eee6201b853b6c4be104edfba4f8f6c5f3623f8e1dba90634d63eb35"},
-    {file = "pydantic-1.10.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6195ca908045054dd2d57eb9c39a5fe86409968b8040de8c2240186da0769da7"},
-    {file = "pydantic-1.10.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:43cdeca8d30de9a897440e3fb8866f827c4c31f6c73838e3a01a14b03b067b1d"},
-    {file = "pydantic-1.10.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c19eb5163167489cb1e0161ae9220dadd4fc609a42649e7e84a8fa8fff7a80f"},
-    {file = "pydantic-1.10.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:012c99a9c0d18cfde7469aa1ebff922e24b0c706d03ead96940f5465f2c9cf62"},
-    {file = "pydantic-1.10.6-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:528dcf7ec49fb5a84bf6fe346c1cc3c55b0e7603c2123881996ca3ad79db5bfc"},
-    {file = "pydantic-1.10.6-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:163e79386c3547c49366e959d01e37fc30252285a70619ffc1b10ede4758250a"},
-    {file = "pydantic-1.10.6-cp39-cp39-win_amd64.whl", hash = "sha256:189318051c3d57821f7233ecc94708767dd67687a614a4e8f92b4a020d4ffd06"},
-    {file = "pydantic-1.10.6-py3-none-any.whl", hash = "sha256:acc6783751ac9c9bc4680379edd6d286468a1dc8d7d9906cd6f1186ed682b2b0"},
-    {file = "pydantic-1.10.6.tar.gz", hash = "sha256:cf95adb0d1671fc38d8c43dd921ad5814a735e7d9b4d9e437c088002863854fd"},
+    {file = "pydantic-1.10.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1243d28e9b05003a89d72e7915fdb26ffd1d39bdd39b00b7dbe4afae4b557f9d"},
+    {file = "pydantic-1.10.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c0ab53b609c11dfc0c060d94335993cc2b95b2150e25583bec37a49b2d6c6c3f"},
+    {file = "pydantic-1.10.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9613fadad06b4f3bc5db2653ce2f22e0de84a7c6c293909b48f6ed37b83c61f"},
+    {file = "pydantic-1.10.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:df7800cb1984d8f6e249351139667a8c50a379009271ee6236138a22a0c0f319"},
+    {file = "pydantic-1.10.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0c6fafa0965b539d7aab0a673a046466d23b86e4b0e8019d25fd53f4df62c277"},
+    {file = "pydantic-1.10.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e82d4566fcd527eae8b244fa952d99f2ca3172b7e97add0b43e2d97ee77f81ab"},
+    {file = "pydantic-1.10.8-cp310-cp310-win_amd64.whl", hash = "sha256:ab523c31e22943713d80d8d342d23b6f6ac4b792a1e54064a8d0cf78fd64e800"},
+    {file = "pydantic-1.10.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:666bdf6066bf6dbc107b30d034615d2627e2121506c555f73f90b54a463d1f33"},
+    {file = "pydantic-1.10.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:35db5301b82e8661fa9c505c800d0990bc14e9f36f98932bb1d248c0ac5cada5"},
+    {file = "pydantic-1.10.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f90c1e29f447557e9e26afb1c4dbf8768a10cc676e3781b6a577841ade126b85"},
+    {file = "pydantic-1.10.8-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:93e766b4a8226e0708ef243e843105bf124e21331694367f95f4e3b4a92bbb3f"},
+    {file = "pydantic-1.10.8-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:88f195f582851e8db960b4a94c3e3ad25692c1c1539e2552f3df7a9e972ef60e"},
+    {file = "pydantic-1.10.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:34d327c81e68a1ecb52fe9c8d50c8a9b3e90d3c8ad991bfc8f953fb477d42fb4"},
+    {file = "pydantic-1.10.8-cp311-cp311-win_amd64.whl", hash = "sha256:d532bf00f381bd6bc62cabc7d1372096b75a33bc197a312b03f5838b4fb84edd"},
+    {file = "pydantic-1.10.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7d5b8641c24886d764a74ec541d2fc2c7fb19f6da2a4001e6d580ba4a38f7878"},
+    {file = "pydantic-1.10.8-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b1f6cb446470b7ddf86c2e57cd119a24959af2b01e552f60705910663af09a4"},
+    {file = "pydantic-1.10.8-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c33b60054b2136aef8cf190cd4c52a3daa20b2263917c49adad20eaf381e823b"},
+    {file = "pydantic-1.10.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:1952526ba40b220b912cdc43c1c32bcf4a58e3f192fa313ee665916b26befb68"},
+    {file = "pydantic-1.10.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:bb14388ec45a7a0dc429e87def6396f9e73c8c77818c927b6a60706603d5f2ea"},
+    {file = "pydantic-1.10.8-cp37-cp37m-win_amd64.whl", hash = "sha256:16f8c3e33af1e9bb16c7a91fc7d5fa9fe27298e9f299cff6cb744d89d573d62c"},
+    {file = "pydantic-1.10.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1ced8375969673929809d7f36ad322934c35de4af3b5e5b09ec967c21f9f7887"},
+    {file = "pydantic-1.10.8-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:93e6bcfccbd831894a6a434b0aeb1947f9e70b7468f274154d03d71fabb1d7c6"},
+    {file = "pydantic-1.10.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:191ba419b605f897ede9892f6c56fb182f40a15d309ef0142212200a10af4c18"},
+    {file = "pydantic-1.10.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:052d8654cb65174d6f9490cc9b9a200083a82cf5c3c5d3985db765757eb3b375"},
+    {file = "pydantic-1.10.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ceb6a23bf1ba4b837d0cfe378329ad3f351b5897c8d4914ce95b85fba96da5a1"},
+    {file = "pydantic-1.10.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6f2e754d5566f050954727c77f094e01793bcb5725b663bf628fa6743a5a9108"},
+    {file = "pydantic-1.10.8-cp38-cp38-win_amd64.whl", hash = "sha256:6a82d6cda82258efca32b40040228ecf43a548671cb174a1e81477195ed3ed56"},
+    {file = "pydantic-1.10.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3e59417ba8a17265e632af99cc5f35ec309de5980c440c255ab1ca3ae96a3e0e"},
+    {file = "pydantic-1.10.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:84d80219c3f8d4cad44575e18404099c76851bc924ce5ab1c4c8bb5e2a2227d0"},
+    {file = "pydantic-1.10.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e4148e635994d57d834be1182a44bdb07dd867fa3c2d1b37002000646cc5459"},
+    {file = "pydantic-1.10.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:12f7b0bf8553e310e530e9f3a2f5734c68699f42218bf3568ef49cd9b0e44df4"},
+    {file = "pydantic-1.10.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:42aa0c4b5c3025483240a25b09f3c09a189481ddda2ea3a831a9d25f444e03c1"},
+    {file = "pydantic-1.10.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:17aef11cc1b997f9d574b91909fed40761e13fac438d72b81f902226a69dac01"},
+    {file = "pydantic-1.10.8-cp39-cp39-win_amd64.whl", hash = "sha256:66a703d1983c675a6e0fed8953b0971c44dba48a929a2000a493c3772eb61a5a"},
+    {file = "pydantic-1.10.8-py3-none-any.whl", hash = "sha256:7456eb22ed9aaa24ff3e7b4757da20d9e5ce2a81018c1b3ebd81a0b88a18f3b2"},
+    {file = "pydantic-1.10.8.tar.gz", hash = "sha256:1410275520dfa70effadf4c21811d755e7ef9bb1f1d077a21958153a92c8d9ca"},
 ]
 
 [package.dependencies]
@@ -1448,6 +1482,21 @@ typing-extensions = ">=4.2.0"
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
+
+[[package]]
+name = "pygments"
+version = "2.15.1"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "main"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "Pygments-2.15.1-py3-none-any.whl", hash = "sha256:db2db3deb4b4179f399a09054b023b6a586b76499d36965813c71aa8ed7b5fd1"},
+    {file = "Pygments-2.15.1.tar.gz", hash = "sha256:8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c"},
+]
+
+[package.extras]
+plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pytest"
@@ -1520,25 +1569,45 @@ pycryptodome = ["pyasn1", "pycryptodome (>=3.3.1,<4.0.0)"]
 
 [[package]]
 name = "requests"
-version = "2.28.2"
+version = "2.31.0"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
-python-versions = ">=3.7, <4"
+python-versions = ">=3.7"
 files = [
-    {file = "requests-2.28.2-py3-none-any.whl", hash = "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa"},
-    {file = "requests-2.28.2.tar.gz", hash = "sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf"},
+    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
+    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
 ]
 
 [package.dependencies]
 certifi = ">=2017.4.17"
 charset-normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<1.27"
+urllib3 = ">=1.21.1,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "rich"
+version = "13.4.1"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+category = "main"
+optional = true
+python-versions = ">=3.7.0"
+files = [
+    {file = "rich-13.4.1-py3-none-any.whl", hash = "sha256:d204aadb50b936bf6b1a695385429d192bc1fdaf3e8b907e8e26f4c4e4b5bf75"},
+    {file = "rich-13.4.1.tar.gz", hash = "sha256:76f6b65ea7e5c5d924ba80e322231d7cb5b5981aa60bfc1e694f1bc097fe6fe1"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0,<3.0.0"
+pygments = ">=2.13.0,<3.0.0"
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "rsa"
@@ -1580,53 +1649,53 @@ files = [
 
 [[package]]
 name = "sqlalchemy"
-version = "1.4.47"
+version = "1.4.48"
 description = "Database Abstraction Library"
 category = "main"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 files = [
-    {file = "SQLAlchemy-1.4.47-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:dcfb480bfc9e1fab726003ae00a6bfc67a29bad275b63a4e36d17fe7f13a624e"},
-    {file = "SQLAlchemy-1.4.47-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:28fda5a69d6182589892422c5a9b02a8fd1125787aab1d83f1392aa955bf8d0a"},
-    {file = "SQLAlchemy-1.4.47-cp27-cp27m-win32.whl", hash = "sha256:45e799c1a41822eba6bee4e59b0e38764e1a1ee69873ab2889079865e9ea0e23"},
-    {file = "SQLAlchemy-1.4.47-cp27-cp27m-win_amd64.whl", hash = "sha256:10edbb92a9ef611f01b086e271a9f6c1c3e5157c3b0c5ff62310fb2187acbd4a"},
-    {file = "SQLAlchemy-1.4.47-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7a4df53472c9030a8ddb1cce517757ba38a7a25699bbcabd57dcc8a5d53f324e"},
-    {file = "SQLAlchemy-1.4.47-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:511d4abc823152dec49461209607bbfb2df60033c8c88a3f7c93293b8ecbb13d"},
-    {file = "SQLAlchemy-1.4.47-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dbe57f39f531c5d68d5594ea4613daa60aba33bb51a8cc42f96f17bbd6305e8d"},
-    {file = "SQLAlchemy-1.4.47-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ca8ab6748e3ec66afccd8b23ec2f92787a58d5353ce9624dccd770427ee67c82"},
-    {file = "SQLAlchemy-1.4.47-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:299b5c5c060b9fbe51808d0d40d8475f7b3873317640b9b7617c7f988cf59fda"},
-    {file = "SQLAlchemy-1.4.47-cp310-cp310-win32.whl", hash = "sha256:684e5c773222781775c7f77231f412633d8af22493bf35b7fa1029fdf8066d10"},
-    {file = "SQLAlchemy-1.4.47-cp310-cp310-win_amd64.whl", hash = "sha256:2bba39b12b879c7b35cde18b6e14119c5f1a16bd064a48dd2ac62d21366a5e17"},
-    {file = "SQLAlchemy-1.4.47-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:795b5b9db573d3ed61fae74285d57d396829e3157642794d3a8f72ec2a5c719b"},
-    {file = "SQLAlchemy-1.4.47-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:989c62b96596b7938cbc032e39431e6c2d81b635034571d6a43a13920852fb65"},
-    {file = "SQLAlchemy-1.4.47-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3b67bda733da1dcdccaf354e71ef01b46db483a4f6236450d3f9a61efdba35a"},
-    {file = "SQLAlchemy-1.4.47-cp311-cp311-win32.whl", hash = "sha256:9a198f690ac12a3a807e03a5a45df6a30cd215935f237a46f4248faed62e69c8"},
-    {file = "SQLAlchemy-1.4.47-cp311-cp311-win_amd64.whl", hash = "sha256:03be6f3cb66e69fb3a09b5ea89d77e4bc942f3bf84b207dba84666a26799c166"},
-    {file = "SQLAlchemy-1.4.47-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:16ee6fea316790980779268da47a9260d5dd665c96f225d28e7750b0bb2e2a04"},
-    {file = "SQLAlchemy-1.4.47-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:557675e0befafa08d36d7a9284e8761c97490a248474d778373fb96b0d7fd8de"},
-    {file = "SQLAlchemy-1.4.47-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bb2797fee8a7914fb2c3dc7de404d3f96eb77f20fc60e9ee38dc6b0ca720f2c2"},
-    {file = "SQLAlchemy-1.4.47-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28297aa29e035f29cba6b16aacd3680fbc6a9db682258d5f2e7b49ec215dbe40"},
-    {file = "SQLAlchemy-1.4.47-cp36-cp36m-win32.whl", hash = "sha256:998e782c8d9fd57fa8704d149ccd52acf03db30d7dd76f467fd21c1c21b414fa"},
-    {file = "SQLAlchemy-1.4.47-cp36-cp36m-win_amd64.whl", hash = "sha256:dde4d02213f1deb49eaaf8be8a6425948963a7af84983b3f22772c63826944de"},
-    {file = "SQLAlchemy-1.4.47-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:e98ef1babe34f37f443b7211cd3ee004d9577a19766e2dbacf62fce73c76245a"},
-    {file = "SQLAlchemy-1.4.47-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14a3879853208a242b5913f3a17c6ac0eae9dc210ff99c8f10b19d4a1ed8ed9b"},
-    {file = "SQLAlchemy-1.4.47-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7120a2f72599d4fed7c001fa1cbbc5b4d14929436135768050e284f53e9fbe5e"},
-    {file = "SQLAlchemy-1.4.47-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:048509d7f3ac27b83ad82fd96a1ab90a34c8e906e4e09c8d677fc531d12c23c5"},
-    {file = "SQLAlchemy-1.4.47-cp37-cp37m-win32.whl", hash = "sha256:6572d7c96c2e3e126d0bb27bfb1d7e2a195b68d951fcc64c146b94f088e5421a"},
-    {file = "SQLAlchemy-1.4.47-cp37-cp37m-win_amd64.whl", hash = "sha256:a6c3929df5eeaf3867724003d5c19fed3f0c290f3edc7911616616684f200ecf"},
-    {file = "SQLAlchemy-1.4.47-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:71d4bf7768169c4502f6c2b0709a02a33703544f611810fb0c75406a9c576ee1"},
-    {file = "SQLAlchemy-1.4.47-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd45c60cc4f6d68c30d5179e2c2c8098f7112983532897566bb69c47d87127d3"},
-    {file = "SQLAlchemy-1.4.47-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0fdbb8e9d4e9003f332a93d6a37bca48ba8095086c97a89826a136d8eddfc455"},
-    {file = "SQLAlchemy-1.4.47-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f216a51451a0a0466e082e163591f6dcb2f9ec182adb3f1f4b1fd3688c7582c"},
-    {file = "SQLAlchemy-1.4.47-cp38-cp38-win32.whl", hash = "sha256:bd988b3362d7e586ef581eb14771bbb48793a4edb6fcf62da75d3f0f3447060b"},
-    {file = "SQLAlchemy-1.4.47-cp38-cp38-win_amd64.whl", hash = "sha256:32ab09f2863e3de51529aa84ff0e4fe89a2cb1bfbc11e225b6dbc60814e44c94"},
-    {file = "SQLAlchemy-1.4.47-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:07764b240645627bc3e82596435bd1a1884646bfc0721642d24c26b12f1df194"},
-    {file = "SQLAlchemy-1.4.47-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e2a42017984099ef6f56438a6b898ce0538f6fadddaa902870c5aa3e1d82583"},
-    {file = "SQLAlchemy-1.4.47-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6b6d807c76c20b4bc143a49ad47782228a2ac98bdcdcb069da54280e138847fc"},
-    {file = "SQLAlchemy-1.4.47-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a94632ba26a666e7be0a7d7cc3f7acab622a04259a3aa0ee50ff6d44ba9df0d"},
-    {file = "SQLAlchemy-1.4.47-cp39-cp39-win32.whl", hash = "sha256:f80915681ea9001f19b65aee715115f2ad310730c8043127cf3e19b3009892dd"},
-    {file = "SQLAlchemy-1.4.47-cp39-cp39-win_amd64.whl", hash = "sha256:fc700b862e0a859a37faf85367e205e7acaecae5a098794aff52fdd8aea77b12"},
-    {file = "SQLAlchemy-1.4.47.tar.gz", hash = "sha256:95fc02f7fc1f3199aaa47a8a757437134cf618e9d994c84effd53f530c38586f"},
+    {file = "SQLAlchemy-1.4.48-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:4bac3aa3c3d8bc7408097e6fe8bf983caa6e9491c5d2e2488cfcfd8106f13b6a"},
+    {file = "SQLAlchemy-1.4.48-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:dbcae0e528d755f4522cad5842f0942e54b578d79f21a692c44d91352ea6d64e"},
+    {file = "SQLAlchemy-1.4.48-cp27-cp27m-win32.whl", hash = "sha256:cbbe8b8bffb199b225d2fe3804421b7b43a0d49983f81dc654d0431d2f855543"},
+    {file = "SQLAlchemy-1.4.48-cp27-cp27m-win_amd64.whl", hash = "sha256:627e04a5d54bd50628fc8734d5fc6df2a1aa5962f219c44aad50b00a6cdcf965"},
+    {file = "SQLAlchemy-1.4.48-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:9af1db7a287ef86e0f5cd990b38da6bd9328de739d17e8864f1817710da2d217"},
+    {file = "SQLAlchemy-1.4.48-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:ce7915eecc9c14a93b73f4e1c9d779ca43e955b43ddf1e21df154184f39748e5"},
+    {file = "SQLAlchemy-1.4.48-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5381ddd09a99638f429f4cbe1b71b025bed318f6a7b23e11d65f3eed5e181c33"},
+    {file = "SQLAlchemy-1.4.48-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:87609f6d4e81a941a17e61a4c19fee57f795e96f834c4f0a30cee725fc3f81d9"},
+    {file = "SQLAlchemy-1.4.48-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb0808ad34167f394fea21bd4587fc62f3bd81bba232a1e7fbdfa17e6cfa7cd7"},
+    {file = "SQLAlchemy-1.4.48-cp310-cp310-win32.whl", hash = "sha256:d53cd8bc582da5c1c8c86b6acc4ef42e20985c57d0ebc906445989df566c5603"},
+    {file = "SQLAlchemy-1.4.48-cp310-cp310-win_amd64.whl", hash = "sha256:4355e5915844afdc5cf22ec29fba1010166e35dd94a21305f49020022167556b"},
+    {file = "SQLAlchemy-1.4.48-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:066c2b0413e8cb980e6d46bf9d35ca83be81c20af688fedaef01450b06e4aa5e"},
+    {file = "SQLAlchemy-1.4.48-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c99bf13e07140601d111a7c6f1fc1519914dd4e5228315bbda255e08412f61a4"},
+    {file = "SQLAlchemy-1.4.48-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ee26276f12614d47cc07bc85490a70f559cba965fb178b1c45d46ffa8d73fda"},
+    {file = "SQLAlchemy-1.4.48-cp311-cp311-win32.whl", hash = "sha256:49c312bcff4728bffc6fb5e5318b8020ed5c8b958a06800f91859fe9633ca20e"},
+    {file = "SQLAlchemy-1.4.48-cp311-cp311-win_amd64.whl", hash = "sha256:cef2e2abc06eab187a533ec3e1067a71d7bbec69e582401afdf6d8cad4ba3515"},
+    {file = "SQLAlchemy-1.4.48-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:3509159e050bd6d24189ec7af373359f07aed690db91909c131e5068176c5a5d"},
+    {file = "SQLAlchemy-1.4.48-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2fc2ab4d9f6d9218a5caa4121bdcf1125303482a1cdcfcdbd8567be8518969c0"},
+    {file = "SQLAlchemy-1.4.48-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e1ddbbcef9bcedaa370c03771ebec7e39e3944782bef49e69430383c376a250b"},
+    {file = "SQLAlchemy-1.4.48-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f82d8efea1ca92b24f51d3aea1a82897ed2409868a0af04247c8c1e4fef5890"},
+    {file = "SQLAlchemy-1.4.48-cp36-cp36m-win32.whl", hash = "sha256:e3e98d4907805b07743b583a99ecc58bf8807ecb6985576d82d5e8ae103b5272"},
+    {file = "SQLAlchemy-1.4.48-cp36-cp36m-win_amd64.whl", hash = "sha256:25887b4f716e085a1c5162f130b852f84e18d2633942c8ca40dfb8519367c14f"},
+    {file = "SQLAlchemy-1.4.48-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:0817c181271b0ce5df1aa20949f0a9e2426830fed5ecdcc8db449618f12c2730"},
+    {file = "SQLAlchemy-1.4.48-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fe1dd2562313dd9fe1778ed56739ad5d9aae10f9f43d9f4cf81d65b0c85168bb"},
+    {file = "SQLAlchemy-1.4.48-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:68413aead943883b341b2b77acd7a7fe2377c34d82e64d1840860247cec7ff7c"},
+    {file = "SQLAlchemy-1.4.48-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fbde5642104ac6e95f96e8ad6d18d9382aa20672008cf26068fe36f3004491df"},
+    {file = "SQLAlchemy-1.4.48-cp37-cp37m-win32.whl", hash = "sha256:11c6b1de720f816c22d6ad3bbfa2f026f89c7b78a5c4ffafb220e0183956a92a"},
+    {file = "SQLAlchemy-1.4.48-cp37-cp37m-win_amd64.whl", hash = "sha256:eb5464ee8d4bb6549d368b578e9529d3c43265007193597ddca71c1bae6174e6"},
+    {file = "SQLAlchemy-1.4.48-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:92e6133cf337c42bfee03ca08c62ba0f2d9695618c8abc14a564f47503157be9"},
+    {file = "SQLAlchemy-1.4.48-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:44d29a3fc6d9c45962476b470a81983dd8add6ad26fdbfae6d463b509d5adcda"},
+    {file = "SQLAlchemy-1.4.48-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:005e942b451cad5285015481ae4e557ff4154dde327840ba91b9ac379be3b6ce"},
+    {file = "SQLAlchemy-1.4.48-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c8cfe951ed074ba5e708ed29c45397a95c4143255b0d022c7c8331a75ae61f3"},
+    {file = "SQLAlchemy-1.4.48-cp38-cp38-win32.whl", hash = "sha256:2b9af65cc58726129d8414fc1a1a650dcdd594ba12e9c97909f1f57d48e393d3"},
+    {file = "SQLAlchemy-1.4.48-cp38-cp38-win_amd64.whl", hash = "sha256:2b562e9d1e59be7833edf28b0968f156683d57cabd2137d8121806f38a9d58f4"},
+    {file = "SQLAlchemy-1.4.48-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:a1fc046756cf2a37d7277c93278566ddf8be135c6a58397b4c940abf837011f4"},
+    {file = "SQLAlchemy-1.4.48-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d9b55252d2ca42a09bcd10a697fa041e696def9dfab0b78c0aaea1485551a08"},
+    {file = "SQLAlchemy-1.4.48-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6dab89874e72a9ab5462997846d4c760cdb957958be27b03b49cf0de5e5c327c"},
+    {file = "SQLAlchemy-1.4.48-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1fd8b5ee5a3acc4371f820934b36f8109ce604ee73cc668c724abb054cebcb6e"},
+    {file = "SQLAlchemy-1.4.48-cp39-cp39-win32.whl", hash = "sha256:eee09350fd538e29cfe3a496ec6f148504d2da40dbf52adefb0d2f8e4d38ccc4"},
+    {file = "SQLAlchemy-1.4.48-cp39-cp39-win_amd64.whl", hash = "sha256:7ad2b0f6520ed5038e795cc2852eb5c1f20fa6831d73301ced4aafbe3a10e1f6"},
+    {file = "SQLAlchemy-1.4.48.tar.gz", hash = "sha256:b47bc287096d989a0838ce96f7d8e966914a24da877ed41a7531d44b55cdb8df"},
 ]
 
 [package.dependencies]
@@ -1682,116 +1751,139 @@ files = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.9.0"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+category = "main"
+optional = true
+python-versions = ">=3.6"
+files = [
+    {file = "typer-0.9.0-py3-none-any.whl", hash = "sha256:5d96d986a21493606a358cae4461bd8cdf83cbf33a5aa950ae629ca3b51467ee"},
+    {file = "typer-0.9.0.tar.gz", hash = "sha256:50922fd79aea2f4751a8e0408ff10d2662bd0c8bbfa84755a699f3bada2978b2"},
+]
+
+[package.dependencies]
+click = ">=7.1.1,<9.0.0"
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
+doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pillow (>=9.3.0,<10.0.0)"]
+test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+
+[[package]]
 name = "typing-extensions"
-version = "4.5.0"
+version = "4.6.3"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
-    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
+    {file = "typing_extensions-4.6.3-py3-none-any.whl", hash = "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26"},
+    {file = "typing_extensions-4.6.3.tar.gz", hash = "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"},
 ]
 
 [[package]]
 name = "urllib3"
-version = "1.26.15"
+version = "2.0.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.7"
 files = [
-    {file = "urllib3-1.26.15-py2.py3-none-any.whl", hash = "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"},
-    {file = "urllib3-1.26.15.tar.gz", hash = "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305"},
+    {file = "urllib3-2.0.2-py3-none-any.whl", hash = "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"},
+    {file = "urllib3-2.0.2.tar.gz", hash = "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "yarl"
-version = "1.8.2"
+version = "1.9.2"
 description = "Yet another URL library"
 category = "main"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "yarl-1.8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bb81f753c815f6b8e2ddd2eef3c855cf7da193b82396ac013c661aaa6cc6b0a5"},
-    {file = "yarl-1.8.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:47d49ac96156f0928f002e2424299b2c91d9db73e08c4cd6742923a086f1c863"},
-    {file = "yarl-1.8.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3fc056e35fa6fba63248d93ff6e672c096f95f7836938241ebc8260e062832fe"},
-    {file = "yarl-1.8.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58a3c13d1c3005dbbac5c9f0d3210b60220a65a999b1833aa46bd6677c69b08e"},
-    {file = "yarl-1.8.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:10b08293cda921157f1e7c2790999d903b3fd28cd5c208cf8826b3b508026996"},
-    {file = "yarl-1.8.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:de986979bbd87272fe557e0a8fcb66fd40ae2ddfe28a8b1ce4eae22681728fef"},
-    {file = "yarl-1.8.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c4fcfa71e2c6a3cb568cf81aadc12768b9995323186a10827beccf5fa23d4f8"},
-    {file = "yarl-1.8.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae4d7ff1049f36accde9e1ef7301912a751e5bae0a9d142459646114c70ecba6"},
-    {file = "yarl-1.8.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:bf071f797aec5b96abfc735ab97da9fd8f8768b43ce2abd85356a3127909d146"},
-    {file = "yarl-1.8.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:74dece2bfc60f0f70907c34b857ee98f2c6dd0f75185db133770cd67300d505f"},
-    {file = "yarl-1.8.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:df60a94d332158b444301c7f569659c926168e4d4aad2cfbf4bce0e8fb8be826"},
-    {file = "yarl-1.8.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:63243b21c6e28ec2375f932a10ce7eda65139b5b854c0f6b82ed945ba526bff3"},
-    {file = "yarl-1.8.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cfa2bbca929aa742b5084fd4663dd4b87c191c844326fcb21c3afd2d11497f80"},
-    {file = "yarl-1.8.2-cp310-cp310-win32.whl", hash = "sha256:b05df9ea7496df11b710081bd90ecc3a3db6adb4fee36f6a411e7bc91a18aa42"},
-    {file = "yarl-1.8.2-cp310-cp310-win_amd64.whl", hash = "sha256:24ad1d10c9db1953291f56b5fe76203977f1ed05f82d09ec97acb623a7976574"},
-    {file = "yarl-1.8.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2a1fca9588f360036242f379bfea2b8b44cae2721859b1c56d033adfd5893634"},
-    {file = "yarl-1.8.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f37db05c6051eff17bc832914fe46869f8849de5b92dc4a3466cd63095d23dfd"},
-    {file = "yarl-1.8.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:77e913b846a6b9c5f767b14dc1e759e5aff05502fe73079f6f4176359d832581"},
-    {file = "yarl-1.8.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0978f29222e649c351b173da2b9b4665ad1feb8d1daa9d971eb90df08702668a"},
-    {file = "yarl-1.8.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:388a45dc77198b2460eac0aca1efd6a7c09e976ee768b0d5109173e521a19daf"},
-    {file = "yarl-1.8.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2305517e332a862ef75be8fad3606ea10108662bc6fe08509d5ca99503ac2aee"},
-    {file = "yarl-1.8.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42430ff511571940d51e75cf42f1e4dbdded477e71c1b7a17f4da76c1da8ea76"},
-    {file = "yarl-1.8.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3150078118f62371375e1e69b13b48288e44f6691c1069340081c3fd12c94d5b"},
-    {file = "yarl-1.8.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c15163b6125db87c8f53c98baa5e785782078fbd2dbeaa04c6141935eb6dab7a"},
-    {file = "yarl-1.8.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4d04acba75c72e6eb90745447d69f84e6c9056390f7a9724605ca9c56b4afcc6"},
-    {file = "yarl-1.8.2-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:e7fd20d6576c10306dea2d6a5765f46f0ac5d6f53436217913e952d19237efc4"},
-    {file = "yarl-1.8.2-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:75c16b2a900b3536dfc7014905a128a2bea8fb01f9ee26d2d7d8db0a08e7cb2c"},
-    {file = "yarl-1.8.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6d88056a04860a98341a0cf53e950e3ac9f4e51d1b6f61a53b0609df342cc8b2"},
-    {file = "yarl-1.8.2-cp311-cp311-win32.whl", hash = "sha256:fb742dcdd5eec9f26b61224c23baea46c9055cf16f62475e11b9b15dfd5c117b"},
-    {file = "yarl-1.8.2-cp311-cp311-win_amd64.whl", hash = "sha256:8c46d3d89902c393a1d1e243ac847e0442d0196bbd81aecc94fcebbc2fd5857c"},
-    {file = "yarl-1.8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ceff9722e0df2e0a9e8a79c610842004fa54e5b309fe6d218e47cd52f791d7ef"},
-    {file = "yarl-1.8.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f6b4aca43b602ba0f1459de647af954769919c4714706be36af670a5f44c9c1"},
-    {file = "yarl-1.8.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1684a9bd9077e922300ecd48003ddae7a7474e0412bea38d4631443a91d61077"},
-    {file = "yarl-1.8.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ebb78745273e51b9832ef90c0898501006670d6e059f2cdb0e999494eb1450c2"},
-    {file = "yarl-1.8.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3adeef150d528ded2a8e734ebf9ae2e658f4c49bf413f5f157a470e17a4a2e89"},
-    {file = "yarl-1.8.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:57a7c87927a468e5a1dc60c17caf9597161d66457a34273ab1760219953f7f4c"},
-    {file = "yarl-1.8.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:efff27bd8cbe1f9bd127e7894942ccc20c857aa8b5a0327874f30201e5ce83d0"},
-    {file = "yarl-1.8.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:a783cd344113cb88c5ff7ca32f1f16532a6f2142185147822187913eb989f739"},
-    {file = "yarl-1.8.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:705227dccbe96ab02c7cb2c43e1228e2826e7ead880bb19ec94ef279e9555b5b"},
-    {file = "yarl-1.8.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:34c09b43bd538bf6c4b891ecce94b6fa4f1f10663a8d4ca589a079a5018f6ed7"},
-    {file = "yarl-1.8.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:a48f4f7fea9a51098b02209d90297ac324241bf37ff6be6d2b0149ab2bd51b37"},
-    {file = "yarl-1.8.2-cp37-cp37m-win32.whl", hash = "sha256:0414fd91ce0b763d4eadb4456795b307a71524dbacd015c657bb2a39db2eab89"},
-    {file = "yarl-1.8.2-cp37-cp37m-win_amd64.whl", hash = "sha256:d881d152ae0007809c2c02e22aa534e702f12071e6b285e90945aa3c376463c5"},
-    {file = "yarl-1.8.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5df5e3d04101c1e5c3b1d69710b0574171cc02fddc4b23d1b2813e75f35a30b1"},
-    {file = "yarl-1.8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7a66c506ec67eb3159eea5096acd05f5e788ceec7b96087d30c7d2865a243918"},
-    {file = "yarl-1.8.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2b4fa2606adf392051d990c3b3877d768771adc3faf2e117b9de7eb977741229"},
-    {file = "yarl-1.8.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e21fb44e1eff06dd6ef971d4bdc611807d6bd3691223d9c01a18cec3677939e"},
-    {file = "yarl-1.8.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:93202666046d9edadfe9f2e7bf5e0782ea0d497b6d63da322e541665d65a044e"},
-    {file = "yarl-1.8.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fc77086ce244453e074e445104f0ecb27530d6fd3a46698e33f6c38951d5a0f1"},
-    {file = "yarl-1.8.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dd68a92cab699a233641f5929a40f02a4ede8c009068ca8aa1fe87b8c20ae3"},
-    {file = "yarl-1.8.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1b372aad2b5f81db66ee7ec085cbad72c4da660d994e8e590c997e9b01e44901"},
-    {file = "yarl-1.8.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e6f3515aafe0209dd17fb9bdd3b4e892963370b3de781f53e1746a521fb39fc0"},
-    {file = "yarl-1.8.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:dfef7350ee369197106805e193d420b75467b6cceac646ea5ed3049fcc950a05"},
-    {file = "yarl-1.8.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:728be34f70a190566d20aa13dc1f01dc44b6aa74580e10a3fb159691bc76909d"},
-    {file = "yarl-1.8.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:ff205b58dc2929191f68162633d5e10e8044398d7a45265f90a0f1d51f85f72c"},
-    {file = "yarl-1.8.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:baf211dcad448a87a0d9047dc8282d7de59473ade7d7fdf22150b1d23859f946"},
-    {file = "yarl-1.8.2-cp38-cp38-win32.whl", hash = "sha256:272b4f1599f1b621bf2aabe4e5b54f39a933971f4e7c9aa311d6d7dc06965165"},
-    {file = "yarl-1.8.2-cp38-cp38-win_amd64.whl", hash = "sha256:326dd1d3caf910cd26a26ccbfb84c03b608ba32499b5d6eeb09252c920bcbe4f"},
-    {file = "yarl-1.8.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f8ca8ad414c85bbc50f49c0a106f951613dfa5f948ab69c10ce9b128d368baf8"},
-    {file = "yarl-1.8.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:418857f837347e8aaef682679f41e36c24250097f9e2f315d39bae3a99a34cbf"},
-    {file = "yarl-1.8.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ae0eec05ab49e91a78700761777f284c2df119376e391db42c38ab46fd662b77"},
-    {file = "yarl-1.8.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:009a028127e0a1755c38b03244c0bea9d5565630db9c4cf9572496e947137a87"},
-    {file = "yarl-1.8.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3edac5d74bb3209c418805bda77f973117836e1de7c000e9755e572c1f7850d0"},
-    {file = "yarl-1.8.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:da65c3f263729e47351261351b8679c6429151ef9649bba08ef2528ff2c423b2"},
-    {file = "yarl-1.8.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ef8fb25e52663a1c85d608f6dd72e19bd390e2ecaf29c17fb08f730226e3a08"},
-    {file = "yarl-1.8.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bcd7bb1e5c45274af9a1dd7494d3c52b2be5e6bd8d7e49c612705fd45420b12d"},
-    {file = "yarl-1.8.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:44ceac0450e648de86da8e42674f9b7077d763ea80c8ceb9d1c3e41f0f0a9951"},
-    {file = "yarl-1.8.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:97209cc91189b48e7cfe777237c04af8e7cc51eb369004e061809bcdf4e55220"},
-    {file = "yarl-1.8.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:48dd18adcf98ea9cd721a25313aef49d70d413a999d7d89df44f469edfb38a06"},
-    {file = "yarl-1.8.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:e59399dda559688461762800d7fb34d9e8a6a7444fd76ec33220a926c8be1516"},
-    {file = "yarl-1.8.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d617c241c8c3ad5c4e78a08429fa49e4b04bedfc507b34b4d8dceb83b4af3588"},
-    {file = "yarl-1.8.2-cp39-cp39-win32.whl", hash = "sha256:cb6d48d80a41f68de41212f3dfd1a9d9898d7841c8f7ce6696cf2fd9cb57ef83"},
-    {file = "yarl-1.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:6604711362f2dbf7160df21c416f81fac0de6dbcf0b5445a2ef25478ecc4c778"},
-    {file = "yarl-1.8.2.tar.gz", hash = "sha256:49d43402c6e3013ad0978602bf6bf5328535c48d192304b91b97a3c6790b1562"},
+    {file = "yarl-1.9.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8c2ad583743d16ddbdf6bb14b5cd76bf43b0d0006e918809d5d4ddf7bde8dd82"},
+    {file = "yarl-1.9.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:82aa6264b36c50acfb2424ad5ca537a2060ab6de158a5bd2a72a032cc75b9eb8"},
+    {file = "yarl-1.9.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c0c77533b5ed4bcc38e943178ccae29b9bcf48ffd1063f5821192f23a1bd27b9"},
+    {file = "yarl-1.9.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee4afac41415d52d53a9833ebae7e32b344be72835bbb589018c9e938045a560"},
+    {file = "yarl-1.9.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9bf345c3a4f5ba7f766430f97f9cc1320786f19584acc7086491f45524a551ac"},
+    {file = "yarl-1.9.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2a96c19c52ff442a808c105901d0bdfd2e28575b3d5f82e2f5fd67e20dc5f4ea"},
+    {file = "yarl-1.9.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:891c0e3ec5ec881541f6c5113d8df0315ce5440e244a716b95f2525b7b9f3608"},
+    {file = "yarl-1.9.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c3a53ba34a636a256d767c086ceb111358876e1fb6b50dfc4d3f4951d40133d5"},
+    {file = "yarl-1.9.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:566185e8ebc0898b11f8026447eacd02e46226716229cea8db37496c8cdd26e0"},
+    {file = "yarl-1.9.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:2b0738fb871812722a0ac2154be1f049c6223b9f6f22eec352996b69775b36d4"},
+    {file = "yarl-1.9.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:32f1d071b3f362c80f1a7d322bfd7b2d11e33d2adf395cc1dd4df36c9c243095"},
+    {file = "yarl-1.9.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:e9fdc7ac0d42bc3ea78818557fab03af6181e076a2944f43c38684b4b6bed8e3"},
+    {file = "yarl-1.9.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:56ff08ab5df8429901ebdc5d15941b59f6253393cb5da07b4170beefcf1b2528"},
+    {file = "yarl-1.9.2-cp310-cp310-win32.whl", hash = "sha256:8ea48e0a2f931064469bdabca50c2f578b565fc446f302a79ba6cc0ee7f384d3"},
+    {file = "yarl-1.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:50f33040f3836e912ed16d212f6cc1efb3231a8a60526a407aeb66c1c1956dde"},
+    {file = "yarl-1.9.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:646d663eb2232d7909e6601f1a9107e66f9791f290a1b3dc7057818fe44fc2b6"},
+    {file = "yarl-1.9.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:aff634b15beff8902d1f918012fc2a42e0dbae6f469fce134c8a0dc51ca423bb"},
+    {file = "yarl-1.9.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a83503934c6273806aed765035716216cc9ab4e0364f7f066227e1aaea90b8d0"},
+    {file = "yarl-1.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b25322201585c69abc7b0e89e72790469f7dad90d26754717f3310bfe30331c2"},
+    {file = "yarl-1.9.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:22a94666751778629f1ec4280b08eb11815783c63f52092a5953faf73be24191"},
+    {file = "yarl-1.9.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ec53a0ea2a80c5cd1ab397925f94bff59222aa3cf9c6da938ce05c9ec20428d"},
+    {file = "yarl-1.9.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:159d81f22d7a43e6eabc36d7194cb53f2f15f498dbbfa8edc8a3239350f59fe7"},
+    {file = "yarl-1.9.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:832b7e711027c114d79dffb92576acd1bd2decc467dec60e1cac96912602d0e6"},
+    {file = "yarl-1.9.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:95d2ecefbcf4e744ea952d073c6922e72ee650ffc79028eb1e320e732898d7e8"},
+    {file = "yarl-1.9.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:d4e2c6d555e77b37288eaf45b8f60f0737c9efa3452c6c44626a5455aeb250b9"},
+    {file = "yarl-1.9.2-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:783185c75c12a017cc345015ea359cc801c3b29a2966c2655cd12b233bf5a2be"},
+    {file = "yarl-1.9.2-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:b8cc1863402472f16c600e3e93d542b7e7542a540f95c30afd472e8e549fc3f7"},
+    {file = "yarl-1.9.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:822b30a0f22e588b32d3120f6d41e4ed021806418b4c9f0bc3048b8c8cb3f92a"},
+    {file = "yarl-1.9.2-cp311-cp311-win32.whl", hash = "sha256:a60347f234c2212a9f0361955007fcf4033a75bf600a33c88a0a8e91af77c0e8"},
+    {file = "yarl-1.9.2-cp311-cp311-win_amd64.whl", hash = "sha256:be6b3fdec5c62f2a67cb3f8c6dbf56bbf3f61c0f046f84645cd1ca73532ea051"},
+    {file = "yarl-1.9.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:38a3928ae37558bc1b559f67410df446d1fbfa87318b124bf5032c31e3447b74"},
+    {file = "yarl-1.9.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac9bb4c5ce3975aeac288cfcb5061ce60e0d14d92209e780c93954076c7c4367"},
+    {file = "yarl-1.9.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3da8a678ca8b96c8606bbb8bfacd99a12ad5dd288bc6f7979baddd62f71c63ef"},
+    {file = "yarl-1.9.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:13414591ff516e04fcdee8dc051c13fd3db13b673c7a4cb1350e6b2ad9639ad3"},
+    {file = "yarl-1.9.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf74d08542c3a9ea97bb8f343d4fcbd4d8f91bba5ec9d5d7f792dbe727f88938"},
+    {file = "yarl-1.9.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6e7221580dc1db478464cfeef9b03b95c5852cc22894e418562997df0d074ccc"},
+    {file = "yarl-1.9.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:494053246b119b041960ddcd20fd76224149cfea8ed8777b687358727911dd33"},
+    {file = "yarl-1.9.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:52a25809fcbecfc63ac9ba0c0fb586f90837f5425edfd1ec9f3372b119585e45"},
+    {file = "yarl-1.9.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:e65610c5792870d45d7b68c677681376fcf9cc1c289f23e8e8b39c1485384185"},
+    {file = "yarl-1.9.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:1b1bba902cba32cdec51fca038fd53f8beee88b77efc373968d1ed021024cc04"},
+    {file = "yarl-1.9.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:662e6016409828ee910f5d9602a2729a8a57d74b163c89a837de3fea050c7582"},
+    {file = "yarl-1.9.2-cp37-cp37m-win32.whl", hash = "sha256:f364d3480bffd3aa566e886587eaca7c8c04d74f6e8933f3f2c996b7f09bee1b"},
+    {file = "yarl-1.9.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6a5883464143ab3ae9ba68daae8e7c5c95b969462bbe42e2464d60e7e2698368"},
+    {file = "yarl-1.9.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5610f80cf43b6202e2c33ba3ec2ee0a2884f8f423c8f4f62906731d876ef4fac"},
+    {file = "yarl-1.9.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b9a4e67ad7b646cd6f0938c7ebfd60e481b7410f574c560e455e938d2da8e0f4"},
+    {file = "yarl-1.9.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:83fcc480d7549ccebe9415d96d9263e2d4226798c37ebd18c930fce43dfb9574"},
+    {file = "yarl-1.9.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fcd436ea16fee7d4207c045b1e340020e58a2597301cfbcfdbe5abd2356c2fb"},
+    {file = "yarl-1.9.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84e0b1599334b1e1478db01b756e55937d4614f8654311eb26012091be109d59"},
+    {file = "yarl-1.9.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3458a24e4ea3fd8930e934c129b676c27452e4ebda80fbe47b56d8c6c7a63a9e"},
+    {file = "yarl-1.9.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:838162460b3a08987546e881a2bfa573960bb559dfa739e7800ceeec92e64417"},
+    {file = "yarl-1.9.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f4e2d08f07a3d7d3e12549052eb5ad3eab1c349c53ac51c209a0e5991bbada78"},
+    {file = "yarl-1.9.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:de119f56f3c5f0e2fb4dee508531a32b069a5f2c6e827b272d1e0ff5ac040333"},
+    {file = "yarl-1.9.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:149ddea5abf329752ea5051b61bd6c1d979e13fbf122d3a1f9f0c8be6cb6f63c"},
+    {file = "yarl-1.9.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:674ca19cbee4a82c9f54e0d1eee28116e63bc6fd1e96c43031d11cbab8b2afd5"},
+    {file = "yarl-1.9.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:9b3152f2f5677b997ae6c804b73da05a39daa6a9e85a512e0e6823d81cdad7cc"},
+    {file = "yarl-1.9.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5415d5a4b080dc9612b1b63cba008db84e908b95848369aa1da3686ae27b6d2b"},
+    {file = "yarl-1.9.2-cp38-cp38-win32.whl", hash = "sha256:f7a3d8146575e08c29ed1cd287068e6d02f1c7bdff8970db96683b9591b86ee7"},
+    {file = "yarl-1.9.2-cp38-cp38-win_amd64.whl", hash = "sha256:63c48f6cef34e6319a74c727376e95626f84ea091f92c0250a98e53e62c77c72"},
+    {file = "yarl-1.9.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:75df5ef94c3fdc393c6b19d80e6ef1ecc9ae2f4263c09cacb178d871c02a5ba9"},
+    {file = "yarl-1.9.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c027a6e96ef77d401d8d5a5c8d6bc478e8042f1e448272e8d9752cb0aff8b5c8"},
+    {file = "yarl-1.9.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f3b078dbe227f79be488ffcfc7a9edb3409d018e0952cf13f15fd6512847f3f7"},
+    {file = "yarl-1.9.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:59723a029760079b7d991a401386390c4be5bfec1e7dd83e25a6a0881859e716"},
+    {file = "yarl-1.9.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b03917871bf859a81ccb180c9a2e6c1e04d2f6a51d953e6a5cdd70c93d4e5a2a"},
+    {file = "yarl-1.9.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c1012fa63eb6c032f3ce5d2171c267992ae0c00b9e164efe4d73db818465fac3"},
+    {file = "yarl-1.9.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a74dcbfe780e62f4b5a062714576f16c2f3493a0394e555ab141bf0d746bb955"},
+    {file = "yarl-1.9.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8c56986609b057b4839968ba901944af91b8e92f1725d1a2d77cbac6972b9ed1"},
+    {file = "yarl-1.9.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2c315df3293cd521033533d242d15eab26583360b58f7ee5d9565f15fee1bef4"},
+    {file = "yarl-1.9.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:b7232f8dfbd225d57340e441d8caf8652a6acd06b389ea2d3222b8bc89cbfca6"},
+    {file = "yarl-1.9.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:53338749febd28935d55b41bf0bcc79d634881195a39f6b2f767870b72514caf"},
+    {file = "yarl-1.9.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:066c163aec9d3d073dc9ffe5dd3ad05069bcb03fcaab8d221290ba99f9f69ee3"},
+    {file = "yarl-1.9.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8288d7cd28f8119b07dd49b7230d6b4562f9b61ee9a4ab02221060d21136be80"},
+    {file = "yarl-1.9.2-cp39-cp39-win32.whl", hash = "sha256:b124e2a6d223b65ba8768d5706d103280914d61f5cae3afbc50fc3dfcc016623"},
+    {file = "yarl-1.9.2-cp39-cp39-win_amd64.whl", hash = "sha256:61016e7d582bc46a5378ffdd02cd0314fb8ba52f40f9cf4d9a5e7dbef88dee18"},
+    {file = "yarl-1.9.2.tar.gz", hash = "sha256:04ab9d4b9f587c06d801c2abfe9317b77cdf996c65a90d5e84ecc45010823571"},
 ]
 
 [package.dependencies]
@@ -1817,7 +1909,7 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [extras]
 auth = ["aiohttp", "python-jose"]
-cli = ["click", "patch"]
+cli = ["patch", "rich", "typer"]
 database = ["SQLAlchemy", "alembic", "asyncpg"]
 graphql = ["aiodataloader", "aiofiles", "graphene"]
 testing = ["pytest", "requests"]
@@ -1825,4 +1917,4 @@ testing = ["pytest", "requests"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "b38f1eb80b767eb20cf3866cdd331646f74db1d7f79077d8d62c6d8681f3f6a2"
+content-hash = "b1c57ae7a9eda0d2b28ca4b37cbbef90fdea8cde31d6b62d66d9e75f7f60f42d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "virga"
-version = "1.4.0"
+version = "1.4.1"
 description = "Dynamic IPA sidecar app generation and plugins."
 authors = ["Elias Gabriel <elias.gabriel@indicodata.ai>"]
 readme = "virga/_cli/templates/boilerplate/README.md"
@@ -12,8 +12,9 @@ python = "^3.7"
 fastapi = "^0.65.2"
 orjson = "^3.5.0"
 
-click = {version = "8.1.0", optional = true}
 patch = {version = "1.16", optional = true}
+typer = {version = "0.9.0", optional = true}
+rich = {version = ">=10.11.0,<14.0.0", optional = true}
 
 python-jose = {extras = ["cryptography"], version = "^3.2.0", optional = true}
 aiohttp = {extras = ["speedups"], version = "^3.8.1", optional = true}
@@ -30,7 +31,7 @@ pytest = {version = ">=3.0.0", optional = true}
 requests = {version="^2.27.1", optional = true}
 
 [tool.poetry.extras]
-cli = ["click", "patch"]
+cli = ["typer", "patch", "rich"]
 auth = ["python-jose", "aiohttp"]
 graphql = ["graphene", "aiofiles", "aiodataloader"]
 database = ["SQLAlchemy", "alembic", "asyncpg"]
@@ -45,6 +46,12 @@ requests = "^2.27.1"
 [tool.poetry.scripts]
 virga = "virga._cli.application:virga"
 
+[tool.pytest.ini_options]
+addopts = "-ra -svv"
+asyncio_mode = "auto"
+testpaths = [
+    "tests"
+]
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "virga"
-version = "1.4.1"
+version = "1.5.0"
 description = "Dynamic IPA sidecar app generation and plugins."
 authors = ["Elias Gabriel <elias.gabriel@indicodata.ai>"]
 readme = "virga/_cli/templates/boilerplate/README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["CHANGELOG.md"]
 
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 fastapi = "^0.65.2"
 orjson = "^3.5.0"
 
@@ -23,7 +23,7 @@ graphene = {version = "^2.1.8", optional = true}
 aiofiles = {version = "^0.8.0", optional = true}
 aiodataloader = {version = "^0.2.1", optional = true}
 
-SQLAlchemy = {version = "^1.4.35", optional = true}
+SQLAlchemy = {version = "~1.4.35", optional = true}
 alembic = {version = "^1.5.5", optional = true}
 asyncpg = {version = "^0.25.0", optional = true}
 
@@ -53,12 +53,17 @@ testpaths = [
     "tests"
 ]
 
+[tool.ruff]
+ignore = ["D205", "D400"]
+
 [tool.mypy]
-ignore_missing_imports = true
+strict = true
 warn_return_any = true
 show_column_numbers = true
-follow_imports = "silent"
 warn_unreachable = true
+explicit_package_bases = true
+check_untyped_defs = true
+plugins = ["sqlalchemy.ext.mypy.plugin"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-asyncio_mode = auto
-markers =
-    integration: mark tests explicitly for integration

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -63,7 +63,8 @@ def test_resolve_template(mock_template, tmp_path):
         assert f.read() == "hello world!\n"
 
 
-def test_copy_template(mock_template, tmp_path):
+def test_copy_template(mock_template, tmp_path, monkeypatch):
+    monkeypatch.setattr("virga._cli.utils._templates_dir", "")
     temp = tmp_path / "mockfile.txt"
 
     temp = copy_template(mock_template, temp, listener="outside world")

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -1,9 +1,7 @@
 import os
 import shutil
 
-import click
 import pytest
-from click.exceptions import UsageError
 
 from virga._cli.utils import (
     copy_template,
@@ -23,21 +21,16 @@ def test_get_path(tmpdir):
     assert get_path(*os.path.split(p2)) == p1
 
 
-def mock_abort():
-    raise UsageError("MOCK ERR")
-
-
-def test_run_command(monkeypatch, tmpdir):
+def test_run_command(tmpdir):
     tempfile = tmpdir.join("file0.txt")
 
     run_command("touch", tempfile)
     assert os.path.exists(tempfile)
 
-    monkeypatch.setattr(click, "get_current_context", mock_abort)
-    with pytest.raises(UsageError):
+    with pytest.raises(Exception):
         run_command("xxxxxx")  # invalid command, OS error
 
-    with pytest.raises(UsageError):
+    with pytest.raises(Exception):
         run_command("ls" "doesnt-exists")  # failed command, runtime error
 
     run_command("rm", tempfile)

--- a/tests/cli/test_virga.py
+++ b/tests/cli/test_virga.py
@@ -15,7 +15,8 @@ def run_command_patch():
     with patch("virga._cli.generators.structure.run_command", mock):
         with patch("virga._cli.generators.webui.run_command", mock):
             with patch("virga._cli.generators.database.run_command", mock):
-                yield mock
+                with patch("virga._cli.generators.deployment.run_command", mock):
+                    yield mock
 
 
 def test_virga_new_exists():
@@ -25,7 +26,7 @@ def test_virga_new_exists():
         os.mkdir("full-directory")
         open("full-directory/file.txt", "a").close()
         result = runner.invoke(virga, ["new", "full-directory"])
-        assert result.exit_code == 2
+        assert result.exit_code == 2, result.output
         assert result.output.find("already exists") > -1
 
 
@@ -34,7 +35,7 @@ def test_virga_new(run_command_patch):
 
     with runner.isolated_filesystem():
         result = runner.invoke(virga, ["new", "new-project"])
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         assert result.output.find("Virga application generation complete!") > -1
 
         assert os.path.isdir("new-project")
@@ -63,7 +64,7 @@ def test_virga_new_good_opts(opts, run_command_patch):
 
     with runner.isolated_filesystem():
         result = runner.invoke(virga, ["new", "new-project", *opts])
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         assert result.output.find("Virga application generation complete!") > -1
 
         expected_extras = [
@@ -82,4 +83,9 @@ def test_virga_new_good_opts(opts, run_command_patch):
 
         # kube is default
         if "--standalone" not in opts:
-            subprocess.run(["helm", "template", "new-project/charts"], check=True)
+            proc = subprocess.run(
+                ["helm", "template", "new-project/charts"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            assert proc.returncode == 0, proc.stdout

--- a/tests/cli/test_virga.py
+++ b/tests/cli/test_virga.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import subprocess
 
 import pytest
-from click.testing import CliRunner
+from typer.testing import CliRunner
 
 from virga._cli.application import virga
 
@@ -67,9 +67,7 @@ def test_virga_new_good_opts(opts, run_command_patch):
         assert result.output.find("Virga application generation complete!") > -1
 
         expected_extras = [
-            f"-E{o[2:]}"
-            for o in opts
-            if o not in ["--webui", "--standalone", "--kubernetes"]
+            f"-E{o[2:]}" for o in opts if o not in ["--webui", "--standalone"]
         ]
         run_command_patch.assert_any_call("poetry", "install")
         run_command_patch.assert_any_call(

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -6,6 +6,8 @@ from sqlalchemy import Column, Integer, String
 from sqlalchemy.orm import declarative_base
 
 from virga.plugins.database import make_async_engine
+
+# the unit tests themselves serve as tests of the `testing` plugin
 from virga.plugins.testing.noct import (  # noqa: F401
     expired_token,
     mock_tokens,

--- a/tests/plugins/test_secure_tokens.py
+++ b/tests/plugins/test_secure_tokens.py
@@ -6,7 +6,6 @@ import pytest
 from virga.plugins.secure_cookies import read_secure_cookie, write_secure_cookie
 
 
-@pytest.mark.integration
 def test_tornado_tokens(mock_tokens):
     (auth_e, refresh_e, auth, refresh) = mock_tokens
     decoded = read_secure_cookie("auth_token", auth_e)

--- a/virga/_cli/application.py
+++ b/virga/_cli/application.py
@@ -25,7 +25,7 @@ virga = typer.Typer(rich_markup_mode="markdown")
 app.add_typer(virga, name="virga")
 
 
-def _to_valid_appname(s):
+def _to_valid_appname(s: str) -> str:
     """
     Return the given string converted to a string that can be used for a clean
     filename. Remove leading and trailing spaces, numbers, and symbols; convert
@@ -42,7 +42,7 @@ def _to_valid_appname(s):
     return re.sub(r"(?u)[^\w]", "", s)
 
 
-def version_callback(ver: bool):
+def version_callback(ver: bool) -> None:
     if ver:
         print(f"[reset]{version('virga')}")
         raise typer.Exit()
@@ -57,7 +57,7 @@ def callback(
         callback=version_callback,
         help="Show the current version of Virga.",
     )
-):
+) -> None:
     """
     Indico Data's CLI tool for generating sidecar applications. Sidecar apps are not
     direct parts of Indico's IPA releases, but offer additional or custom functionality
@@ -113,7 +113,7 @@ def new(
         " Dockerfile that runs Gunicorn as a subprocess-based load balancer.",
         rich_help_panel="Generators",
     ),
-):
+) -> None:
     """
     Create a new project, customized using the provided generations options. If
     unsuccessful, projects will be cleaned up automatically to prevent being left in an

--- a/virga/_cli/application.py
+++ b/virga/_cli/application.py
@@ -3,9 +3,11 @@ import re
 import shutil
 import string
 import tempfile
-from typing import Optional
+from pathlib import Path
+from importlib.metadata import version
 
-import click
+import typer
+from rich import print
 
 from .generators import (
     DatabaseGenerator,
@@ -16,6 +18,11 @@ from .generators import (
     K8DeploymentGenerator,
     StandaloneDeploymentGenerator,
 )
+
+
+app = typer.Typer()
+virga = typer.Typer(rich_markup_mode="markdown")
+app.add_typer(virga, name="virga")
 
 
 def _to_valid_appname(s):
@@ -35,77 +42,89 @@ def _to_valid_appname(s):
     return re.sub(r"(?u)[^\w]", "", s)
 
 
-@click.group()
-@click.version_option()
-def virga():
+def version_callback(ver: bool):
+    if ver:
+        print(f"[reset]{version('virga')}")
+        raise typer.Exit()
+
+
+@virga.callback()
+def callback(
+    ver: bool = typer.Option(
+        False,
+        "--version",
+        is_eager=True,
+        callback=version_callback,
+        help="Show the current version of Virga.",
+    )
+):
     """
-    Indico's CLI tool for generating templated sidecar applications.
+    Indico Data's CLI tool for generating sidecar applications. Sidecar apps are not
+    direct parts of Indico's IPA releases, but offer additional or custom functionality
+    for product or business operations.
     """
     pass
 
 
 @virga.command()
-@click.option(
-    "--name",
-    help="The name of the application to generate.\n\nThis will be used for both the "
-    "Python module and development URL subdomain. If not supplied, this will be parsed"
-    " from the provided APP_PATH.",
-)
-@click.option(
-    "--auth",
-    is_flag=True,
-    help="Adds connection middleware to support Noct authentication.",
-)
-@click.option(
-    "--graphql",
-    is_flag=True,
-    help="Adds a basic GraphQL support through Graphene.",
-)
-@click.option(
-    "--database",
-    is_flag=True,
-    help="Adds Alembic and SQLALchemy support through postgresql and asyncpg.",
-)
-@click.option(
-    "--webui",
-    is_flag=True,
-    help="Adds a basic UI template based on React and Stratosphere.\n\nIn addition"
-    " to the React application itself, this flag will also generate an nginx-based"
-    " Dockerfile for local development and to serve as an app ingress when deployed.",
-)
-@click.option(
-    "--kubernetes/--standalone",
-    default=True,
-    help="Determines the type of project to generate.\n\nA K8 project will output a"
-    " basic and configurable Helm chart. A standalone app will produce an API"
-    " Dockerfile that runs Gunicorn as a subprocess-based load balancer.",
-)
-@click.argument("app_path", type=click.Path(writable=True, resolve_path=True))
-@click.pass_context
-def new(ctx: click.Context, app_path, name: Optional[str] = None, **kwargs):
+def new(
+    ctx: typer.Context,
+    app_path: Path = typer.Argument(..., writable=True, resolve_path=True),
+    name: str = typer.Option(
+        "",
+        help="The name of the application to generate.\n\nThis will be used for both"
+        " the Python module and development URL subdomain. If not supplied, one is"
+        " derived from the given desired project path according to the rules specified"
+        " in PEP-8.",
+    ),
+    auth: bool = typer.Option(
+        False,
+        "--auth",
+        help="Adds connection middleware to support login integration with an IPA"
+        " cluster. This enables shared users between the app and an existing cluster.",
+        rich_help_panel="Generators",
+    ),
+    graphql: bool = typer.Option(
+        False,
+        "--graphql",
+        help="Adds a basic GraphQL route using Graphene via the graphql extra.",
+        rich_help_panel="Generators",
+    ),
+    database: bool = typer.Option(
+        False,
+        "--database",
+        help="Adds Alembic and SQLALchemy support using postgresql and asyncpg via the"
+        " database extra.",
+        rich_help_panel="Generators",
+    ),
+    webui: bool = typer.Option(
+        False,
+        "--webui",
+        help="Adds a basic UI template based on React and Stratosphere.\n\nIn addition"
+        " to the React application itself, this flag will also generate an nginx-based"
+        " Dockerfile for development and to serve as an app ingress when deployed.",
+        rich_help_panel="Generators",
+    ),
+    kubernetes: bool = typer.Option(
+        True,
+        "--kubernetes/--standalone",
+        help="Determines the type of project to generate.\n\nA K8 project will output a"
+        " basic and configurable Helm chart. A standalone app will produce an API"
+        " Dockerfile that runs Gunicorn as a subprocess-based load balancer.",
+        rich_help_panel="Generators",
+    ),
+):
     """
-    Create a new project using provided template options.
-
-    If no name is supplied, one is derived from the given desired project path
-    according to the rules specified in PEP-8. For example:
-
-      - `virga new fruit/banana` generates a new Python module called 'banana' in the
-      directory 'fruit/banana'.
-
-      - `virga new fruit/tropical --name mango` generates a new Python module called
-      mango in the directory 'fruit/tropical'.
-
-    Rules: https://www.python.org/dev/peps/pep-0008/#package-and-module-names
-    """
+    Create a new project, customized using the provided generations options. If
+    unsuccessful, projects will be cleaned up automatically to prevent being left in an
+    incomplete state. If a `--name` is not specified, one is derived from the desired
+    given project path according to the [rules specified in PEP-8](https://www.python.org/dev/peps/pep-0008/#package-and-module-names).
+    """  # noqa: E501
     # sanitize the requested app name to ensure no overwrites
     if os.path.exists(app_path):
-        raise click.BadParameter(
-            click.style(
-                f"'{app_path}' already exists. To create a new project, supply a path "
-                "to a non-existent directory.",
-                fg="red",
-                bold=True,
-            )
+        raise typer.BadParameter(
+            f"'{app_path}' already exists. To create a new project, supply a path to a"
+            " non-existent directory."
         )
 
     app_name = name or _to_valid_appname(os.path.basename(app_path))
@@ -124,49 +143,56 @@ def new(ctx: click.Context, app_path, name: Optional[str] = None, **kwargs):
                 app_name,
                 project_dir,
                 extras=[
-                    f"-E{k}"
-                    for k, v in kwargs.items()
-                    ## these flags don't correlate to py extras
-                    if v and k not in ["webui", "kubernetes", "standalone"]
+                    f"-E{extra}"
+                    for extra, enabled in (
+                        ("auth", auth),
+                        ("graphql", graphql),
+                        ("database", database),
+                    )
+                    if enabled
                 ],
             )
 
             # webapp generation
-            if kwargs["webui"]:
+            if webui:
                 WebUIGenerator.generate(ctx, app_name, project_dir)
 
             # noct integration
-            if kwargs["auth"]:
+            if auth:
                 NoctAuthGenerator.generate(ctx, app_name, project_dir)
 
             # graphql integration
-            if kwargs["graphql"]:
+            if graphql:
                 GraphQLGenerator.generate(ctx, app_name, project_dir)
 
             # database setup
-            if kwargs["database"]:
+            if database:
                 DatabaseGenerator.generate(ctx, app_name, project_dir)
 
             # kubernetes customization
-            if kwargs["kubernetes"]:
-                K8DeploymentGenerator.generate(ctx, app_name, project_dir, **kwargs)
+            if kubernetes:
+                K8DeploymentGenerator.generate(
+                    ctx,
+                    app_name,
+                    project_dir,
+                    webui=webui,
+                    auth=auth,
+                    database=database,
+                )
             else:
                 StandaloneDeploymentGenerator.generate(ctx, app_name, project_dir)
 
             # move the full project to the desired location
             shutil.move(project_dir, app_path)
-            click.echo("\n=========\n")
-            click.secho(
-                "Virga application generation complete!\n", bold=True, fg="green"
+            print("\n[dim]=========\n")
+            print(
+                "[bold green]Virga application generation complete! :confetti_ball:\n"
             )
         except Exception as err:
-            click.echo(
-                "\n=========\n\n"
-                + click.style(
-                    "Virga application generation failed :(",
-                    underline=True,
-                    bold=True,
-                    fg="red",
-                )
-                + click.style(f"\n\n{err}\n", fg="red")
+            print("\n[dim]=========\n")
+            print(
+                "[bold red underline]Virga application generation failed"
+                "[not u] :confounded:"
             )
+            print(f"[red]\n{err}\n")
+            raise typer.Exit(code=1)

--- a/virga/_cli/generators/__init__.py
+++ b/virga/_cli/generators/__init__.py
@@ -1,6 +1,16 @@
-from .auth import NoctAuthGenerator  # noqa
-from .database import DatabaseGenerator  # noqa
-from .graphql import GraphQLGenerator  # noqa
-from .structure import StructureGenerator  # noqa
-from .webui import WebUIGenerator  # noqa
-from .deployment import K8DeploymentGenerator, StandaloneDeploymentGenerator  # noqa
+from .auth import NoctAuthGenerator
+from .database import DatabaseGenerator
+from .graphql import GraphQLGenerator
+from .structure import StructureGenerator
+from .webui import WebUIGenerator
+from .deployment import K8DeploymentGenerator, StandaloneDeploymentGenerator
+
+__all__ = [
+    "NoctAuthGenerator",
+    "DatabaseGenerator",
+    "GraphQLGenerator",
+    "StructureGenerator",
+    "WebUIGenerator",
+    "K8DeploymentGenerator",
+    "StandaloneDeploymentGenerator",
+]

--- a/virga/_cli/generators/auth.py
+++ b/virga/_cli/generators/auth.py
@@ -1,3 +1,4 @@
+from typing import Any
 import os
 
 from typer import Context
@@ -16,7 +17,7 @@ from .base import Generator
 
 class NoctAuthGenerator(Generator):
     @staticmethod
-    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs):
+    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs: Any) -> None:
         """
         Patch the generated base structure to add examples for Noct authentication.
         """

--- a/virga/_cli/generators/auth.py
+++ b/virga/_cli/generators/auth.py
@@ -1,6 +1,6 @@
 import os
 
-import click
+from typer import Context
 
 from ..utils import (
     _print_step,
@@ -16,7 +16,7 @@ from .base import Generator
 
 class NoctAuthGenerator(Generator):
     @staticmethod
-    def generate(ctx: click.Context, app_name: str, project_dir: str, **kwargs):
+    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs):
         """
         Patch the generated base structure to add examples for Noct authentication.
         """

--- a/virga/_cli/generators/auth.py
+++ b/virga/_cli/generators/auth.py
@@ -25,10 +25,10 @@ class NoctAuthGenerator(Generator):
             _print_step("Adding Noct route dependencies...")
 
             with in_directory(get_path(project_dir, "api", app_name)):
-                copy_patch("auth/app.patch", "app.patch")
+                copy_patch("auth/app.patch")
 
             _print_step("Patching existing configs...")
-            copy_patch("auth/Caddyfile.patch", "Caddyfile.patch")
+            copy_patch("auth/Caddyfile.patch")
             copy_template(
                 "auth/docker-compose.patch.template",
                 "docker-compose.patch",

--- a/virga/_cli/generators/auth.py
+++ b/virga/_cli/generators/auth.py
@@ -5,12 +5,11 @@ from typer import Context
 
 from ..utils import (
     _print_step,
-    _templates_dir,
     apply_patch,
     copy_template,
     get_path,
     in_directory,
-    run_patch,
+    copy_patch,
 )
 from .base import Generator
 
@@ -26,14 +25,12 @@ class NoctAuthGenerator(Generator):
             _print_step("Adding Noct route dependencies...")
 
             with in_directory(get_path(project_dir, "api", app_name)):
-                run_patch(get_path(_templates_dir, "auth/app.patch"), "app.patch")
+                copy_patch("auth/app.patch", "app.patch")
 
             _print_step("Patching existing configs...")
-            run_patch(
-                get_path(_templates_dir, "auth/Caddyfile.patch"), "Caddyfile.patch"
-            )
+            copy_patch("auth/Caddyfile.patch", "Caddyfile.patch")
             copy_template(
-                get_path(_templates_dir, "auth/docker-compose.patch.template"),
+                "auth/docker-compose.patch.template",
                 "docker-compose.patch",
                 app_name=app_name,
             )
@@ -42,7 +39,7 @@ class NoctAuthGenerator(Generator):
             # change the noct route in the webui only if it was generated
             if os.path.exists("webui"):
                 copy_template(
-                    get_path(_templates_dir, "auth/app-config.patch.template"),
+                    "auth/app-config.patch.template",
                     "app-config.patch",
                     app_name=app_name,
                 )

--- a/virga/_cli/generators/base.py
+++ b/virga/_cli/generators/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from click import Context
+from typer import Context
 
 
 class Generator(ABC):

--- a/virga/_cli/generators/base.py
+++ b/virga/_cli/generators/base.py
@@ -7,12 +7,12 @@ from typer import Context
 class Generator(ABC):
     """
     The abstract parent class for all generators. Subclasses override the
-    `generate` function to perfrom templating operations based on the
-    command context and any defiend (kw)args.
+    `generate` function to perform template operations based on the
+    command context and any defined (kw)args.
     """
 
     @staticmethod
     @abstractmethod
-    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs: Any):
+    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs: Any) -> None:
         """Run any generator-specific code."""
         raise NotImplementedError()

--- a/virga/_cli/generators/database.py
+++ b/virga/_cli/generators/database.py
@@ -11,7 +11,7 @@ from ..utils import (
     resolve_template,
     # `run_command` isn't called explicitly but required to monkeypatch during testing
     run_command,  # noqa: F401
-    run_patch,
+    copy_patch,
 )
 from .base import Generator
 
@@ -39,17 +39,17 @@ class DatabaseGenerator(Generator):
                 )
 
                 _print_step("Patching generated files...")
-                run_patch(
-                    get_path(_templates_dir, "database/settings.patch"),
+                copy_patch(
+                    "database/settings.patch",
                     "settings.patch",
                 )
-                run_patch(get_path(_templates_dir, "database/app.patch"), "app.patch")
+                copy_patch("database/app.patch", "app.patch")
 
-            run_patch(
-                get_path(_templates_dir, "database/Dockerfile.patch"),
+            copy_patch(
+                "database/Dockerfile.patch",
                 "Dockerfile.patch",
             )
-            run_patch(
-                get_path(_templates_dir, "database/prestart.patch"),
+            copy_patch(
+                "database/prestart.patch",
                 "scripts/prestart.patch",
             )

--- a/virga/_cli/generators/database.py
+++ b/virga/_cli/generators/database.py
@@ -39,17 +39,8 @@ class DatabaseGenerator(Generator):
                 )
 
                 _print_step("Patching generated files...")
-                copy_patch(
-                    "database/settings.patch",
-                    "settings.patch",
-                )
-                copy_patch("database/app.patch", "app.patch")
+                copy_patch("database/settings.patch")
+                copy_patch("database/app.patch")
 
-            copy_patch(
-                "database/Dockerfile.patch",
-                "Dockerfile.patch",
-            )
-            copy_patch(
-                "database/prestart.patch",
-                "scripts/prestart.patch",
-            )
+            copy_patch("database/Dockerfile.patch")
+            copy_patch("database/prestart.patch", dest="scripts/prestart.patch")

--- a/virga/_cli/generators/database.py
+++ b/virga/_cli/generators/database.py
@@ -1,6 +1,6 @@
 import shutil
 
-import click
+from typer import Context
 
 from ..utils import (
     _print_step,
@@ -17,7 +17,7 @@ from .base import Generator
 
 class DatabaseGenerator(Generator):
     @staticmethod
-    def generate(ctx: click.Context, app_name: str, project_dir: str, **kwargs):
+    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs):
         """
         Copy the base Alembic and database setup to the project directory.
         """

--- a/virga/_cli/generators/database.py
+++ b/virga/_cli/generators/database.py
@@ -1,3 +1,4 @@
+from typing import Any
 import shutil
 
 from typer import Context
@@ -17,7 +18,7 @@ from .base import Generator
 
 class DatabaseGenerator(Generator):
     @staticmethod
-    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs):
+    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs: Any) -> None:
         """
         Copy the base Alembic and database setup to the project directory.
         """

--- a/virga/_cli/generators/deployment.py
+++ b/virga/_cli/generators/deployment.py
@@ -5,7 +5,7 @@ from typer import Context
 
 from .base import Generator
 from ..utils import (
-    run_patch,
+    copy_patch,
     in_directory,
     resolve_template,
     get_path,
@@ -40,49 +40,35 @@ class K8DeploymentGenerator(Generator):
                         dirs_exist_ok=True,
                     )
 
-                    run_patch(
-                        get_path(
-                            _templates_dir, "deployment/k8s/webui/values.yaml.patch"
-                        ),
+                    copy_patch(
+                        "deployment/k8s/webui/values.yaml.patch",
                         "values.yaml.patch",
                     )
 
                 # if --auth was specified
                 if kwargs["auth"]:
-                    run_patch(
-                        get_path(
-                            _templates_dir, "deployment/k8s/auth/api-configs.yaml.patch"
-                        ),
+                    copy_patch(
+                        "deployment/k8s/auth/api-configs.yaml.patch",
                         "api-configs.yaml.patch",
                     )
-                    run_patch(
-                        get_path(
-                            _templates_dir, "deployment/k8s/auth/api-secrets.yaml.patch"
-                        ),
+                    copy_patch(
+                        "deployment/k8s/auth/api-secrets.yaml.patch",
                         "api-secrets.yaml.patch",
                     )
-                    run_patch(
-                        get_path(
-                            _templates_dir, "deployment/k8s/auth/values.yaml.patch"
-                        ),
+                    copy_patch(
+                        "deployment/k8s/auth/values.yaml.patch",
                         "values.yaml.patch",
                     )
 
                     # we don't need to patch the auth sections of webui yamls if we
                     # didn't generate the project using the ui flag
                     if kwargs["webui"]:
-                        run_patch(
-                            get_path(
-                                _templates_dir,
-                                "deployment/k8s/auth/webui/ui-app-config.yaml.patch",
-                            ),
+                        copy_patch(
+                            "deployment/k8s/auth/webui/ui-app-config.yaml.patch",
                             "ui-app-config.yaml.patch",
                         )
-                        run_patch(
-                            get_path(
-                                _templates_dir,
-                                "deployment/k8s/auth/webui/values.yaml.patch",
-                            ),
+                        copy_patch(
+                            "deployment/k8s/auth/webui/values.yaml.patch",
                             "values.yaml.patch",
                         )
 
@@ -94,26 +80,18 @@ class K8DeploymentGenerator(Generator):
                         dirs_exist_ok=True,
                     )
 
-                    run_patch(
-                        get_path(
-                            _templates_dir,
-                            "deployment/k8s/database/api-configs.yaml.patch",
-                        ),
+                    copy_patch(
+                        "deployment/k8s/database/api-configs.yaml.patch",
                         "api-configs.yaml.patch",
                     )
 
-                    run_patch(
-                        get_path(
-                            _templates_dir,
-                            "deployment/k8s/database/api-secrets.yaml.patch",
-                        ),
+                    copy_patch(
+                        "deployment/k8s/database/api-secrets.yaml.patch",
                         "api-secrets.yaml.patch",
                     )
 
-                    run_patch(
-                        get_path(
-                            _templates_dir, "deployment/k8s/database/values.yaml.patch"
-                        ),
+                    copy_patch(
+                        "deployment/k8s/database/values.yaml.patch",
                         "values.yaml.patch",
                     )
 
@@ -140,8 +118,8 @@ class StandaloneDeploymentGenerator(Generator):
             run_command("poetry", "add", "gunicorn[gevent]")
 
             _print_step("Patching Dockerfile...")
-            run_patch(
-                get_path(_templates_dir, "deployment/standalone/Dockerfile.patch"),
+            copy_patch(
+                "deployment/standalone/Dockerfile.patch",
                 "Dockerfile.patch",
             )
             resolve_template(

--- a/virga/_cli/generators/deployment.py
+++ b/virga/_cli/generators/deployment.py
@@ -1,4 +1,4 @@
-import click
+from typer import Context
 import shutil
 
 from .base import Generator
@@ -15,7 +15,7 @@ from ..utils import (
 
 class K8DeploymentGenerator(Generator):
     @staticmethod
-    def generate(ctx: click.Context, app_name: str, project_dir: str, **kwargs):
+    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs):
         """
         Copies chart templates and applies the necessary patches to support
         a Helm-based Kubernetes deployment.
@@ -128,7 +128,7 @@ class K8DeploymentGenerator(Generator):
 
 class StandaloneDeploymentGenerator(Generator):
     @staticmethod
-    def generate(ctx: click.Context, app_name: str, project_dir: str, **kwargs):
+    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs):
         """
         Applies patches to the generated Dockerfile and pyproject.toml files in order
         to support a standalone Gunicorn deployment.

--- a/virga/_cli/generators/deployment.py
+++ b/virga/_cli/generators/deployment.py
@@ -1,5 +1,7 @@
-from typer import Context
+from typing import Any
 import shutil
+
+from typer import Context
 
 from .base import Generator
 from ..utils import (
@@ -15,7 +17,7 @@ from ..utils import (
 
 class K8DeploymentGenerator(Generator):
     @staticmethod
-    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs):
+    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs: Any) -> None:
         """
         Copies chart templates and applies the necessary patches to support
         a Helm-based Kubernetes deployment.
@@ -128,7 +130,7 @@ class K8DeploymentGenerator(Generator):
 
 class StandaloneDeploymentGenerator(Generator):
     @staticmethod
-    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs):
+    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs: Any) -> None:
         """
         Applies patches to the generated Dockerfile and pyproject.toml files in order
         to support a standalone Gunicorn deployment.

--- a/virga/_cli/generators/deployment.py
+++ b/virga/_cli/generators/deployment.py
@@ -40,37 +40,19 @@ class K8DeploymentGenerator(Generator):
                         dirs_exist_ok=True,
                     )
 
-                    copy_patch(
-                        "deployment/k8s/webui/values.yaml.patch",
-                        "values.yaml.patch",
-                    )
+                    copy_patch("deployment/k8s/webui/values.yaml.patch")
 
                 # if --auth was specified
                 if kwargs["auth"]:
-                    copy_patch(
-                        "deployment/k8s/auth/api-configs.yaml.patch",
-                        "api-configs.yaml.patch",
-                    )
-                    copy_patch(
-                        "deployment/k8s/auth/api-secrets.yaml.patch",
-                        "api-secrets.yaml.patch",
-                    )
-                    copy_patch(
-                        "deployment/k8s/auth/values.yaml.patch",
-                        "values.yaml.patch",
-                    )
+                    copy_patch("deployment/k8s/auth/api-configs.yaml.patch")
+                    copy_patch("deployment/k8s/auth/api-secrets.yaml.patch")
+                    copy_patch("deployment/k8s/auth/values.yaml.patch")
 
                     # we don't need to patch the auth sections of webui yamls if we
                     # didn't generate the project using the ui flag
                     if kwargs["webui"]:
-                        copy_patch(
-                            "deployment/k8s/auth/webui/ui-app-config.yaml.patch",
-                            "ui-app-config.yaml.patch",
-                        )
-                        copy_patch(
-                            "deployment/k8s/auth/webui/values.yaml.patch",
-                            "values.yaml.patch",
-                        )
+                        copy_patch("deployment/k8s/auth/webui/ui-app-config.yaml.patch")
+                        copy_patch("deployment/k8s/auth/webui/values.yaml.patch")
 
                 # if --database was specified
                 if kwargs["database"]:
@@ -80,20 +62,9 @@ class K8DeploymentGenerator(Generator):
                         dirs_exist_ok=True,
                     )
 
-                    copy_patch(
-                        "deployment/k8s/database/api-configs.yaml.patch",
-                        "api-configs.yaml.patch",
-                    )
-
-                    copy_patch(
-                        "deployment/k8s/database/api-secrets.yaml.patch",
-                        "api-secrets.yaml.patch",
-                    )
-
-                    copy_patch(
-                        "deployment/k8s/database/values.yaml.patch",
-                        "values.yaml.patch",
-                    )
+                    copy_patch("deployment/k8s/database/api-configs.yaml.patch")
+                    copy_patch("deployment/k8s/database/api-secrets.yaml.patch")
+                    copy_patch("deployment/k8s/database/values.yaml.patch")
 
             _print_step("Patching Dockerfile...")
 
@@ -118,10 +89,7 @@ class StandaloneDeploymentGenerator(Generator):
             run_command("poetry", "add", "gunicorn[gevent]")
 
             _print_step("Patching Dockerfile...")
-            copy_patch(
-                "deployment/standalone/Dockerfile.patch",
-                "Dockerfile.patch",
-            )
+            copy_patch("deployment/standalone/Dockerfile.patch")
             resolve_template(
                 "Dockerfile.template", app_name=app_name, entrypoint_cmd='"/start.sh"'
             )

--- a/virga/_cli/generators/graphql.py
+++ b/virga/_cli/generators/graphql.py
@@ -4,7 +4,7 @@ import shutil
 
 from typer import Context
 
-from ..utils import _print_step, _templates_dir, get_path, in_directory, run_patch
+from ..utils import _print_step, _templates_dir, get_path, in_directory, copy_patch
 from .base import Generator
 
 
@@ -23,4 +23,4 @@ class GraphQLGenerator(Generator):
 
                 _print_step("Patching existing code...")
 
-                run_patch(get_path(_templates_dir, "graphql/app.patch"), "app.patch")
+                copy_patch("graphql/app.patch", "app.patch")

--- a/virga/_cli/generators/graphql.py
+++ b/virga/_cli/generators/graphql.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import shutil
 
 from typer import Context
@@ -8,7 +10,7 @@ from .base import Generator
 
 class GraphQLGenerator(Generator):
     @staticmethod
-    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs):
+    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs: Any) -> None:
         """
         Patch the generated base structure to add GraphQL support.
         """

--- a/virga/_cli/generators/graphql.py
+++ b/virga/_cli/generators/graphql.py
@@ -23,4 +23,4 @@ class GraphQLGenerator(Generator):
 
                 _print_step("Patching existing code...")
 
-                copy_patch("graphql/app.patch", "app.patch")
+                copy_patch("graphql/app.patch")

--- a/virga/_cli/generators/graphql.py
+++ b/virga/_cli/generators/graphql.py
@@ -1,6 +1,6 @@
 import shutil
 
-import click
+from typer import Context
 
 from ..utils import _print_step, _templates_dir, get_path, in_directory, run_patch
 from .base import Generator
@@ -8,7 +8,7 @@ from .base import Generator
 
 class GraphQLGenerator(Generator):
     @staticmethod
-    def generate(ctx: click.Context, app_name: str, project_dir: str, **kwargs):
+    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs):
         """
         Patch the generated base structure to add GraphQL support.
         """

--- a/virga/_cli/generators/structure.py
+++ b/virga/_cli/generators/structure.py
@@ -1,3 +1,5 @@
+from typing import List, Any
+
 import shutil
 
 from typer import Context
@@ -15,7 +17,13 @@ from .base import Generator
 
 class StructureGenerator(Generator):
     @staticmethod
-    def generate(ctx: Context, app_name: str, project_dir: str, extras=None, **kwargs):
+    def generate(
+        ctx: Context,
+        app_name: str,
+        project_dir: str,
+        extras: List[str] = [],
+        **kwargs: Any,
+    ) -> None:
         """
         Generate project base files given the the provided APP_NAME.
         """

--- a/virga/_cli/generators/structure.py
+++ b/virga/_cli/generators/structure.py
@@ -1,6 +1,6 @@
 import shutil
 
-import click
+from typer import Context
 
 from ..utils import (
     _print_step,
@@ -15,9 +15,7 @@ from .base import Generator
 
 class StructureGenerator(Generator):
     @staticmethod
-    def generate(
-        ctx: click.Context, app_name: str, project_dir: str, extras=None, **kwargs
-    ):
+    def generate(ctx: Context, app_name: str, project_dir: str, extras=None, **kwargs):
         """
         Generate project base files given the the provided APP_NAME.
         """

--- a/virga/_cli/generators/webui.py
+++ b/virga/_cli/generators/webui.py
@@ -1,6 +1,6 @@
 import shutil
 
-import click
+from typer import Context
 
 from ..utils import (
     _print_step,
@@ -18,7 +18,7 @@ from .base import Generator
 
 class WebUIGenerator(Generator):
     @staticmethod
-    def generate(ctx: click.Context, app_name: str, project_dir: str, **kwargs):
+    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs):
         """
         Patch the generated base structure to add mini-strat.
         """

--- a/virga/_cli/generators/webui.py
+++ b/virga/_cli/generators/webui.py
@@ -38,7 +38,7 @@ class WebUIGenerator(Generator):
             )
             apply_patch("docker-compose.patch")
 
-            copy_patch("webui/Caddyfile.patch", "Caddyfile.patch")
+            copy_patch("webui/Caddyfile.patch")
 
             with in_directory("webui"):
                 resolve_template("package.json.template", app_name=app_name)

--- a/virga/_cli/generators/webui.py
+++ b/virga/_cli/generators/webui.py
@@ -12,7 +12,7 @@ from ..utils import (
     in_directory,
     resolve_template,
     run_command,
-    run_patch,
+    copy_patch,
 )
 from .base import Generator
 
@@ -32,15 +32,13 @@ class WebUIGenerator(Generator):
             # apply patches for docker-compose and nginx
             _print_step("Patching existing configs...")
             copy_template(
-                get_path(_templates_dir, "webui/docker-compose.patch.template"),
+                "webui/docker-compose.patch.template",
                 "docker-compose.patch",
                 app_name=app_name,
             )
             apply_patch("docker-compose.patch")
 
-            run_patch(
-                get_path(_templates_dir, "webui/Caddyfile.patch"), "Caddyfile.patch"
-            )
+            copy_patch("webui/Caddyfile.patch", "Caddyfile.patch")
 
             with in_directory("webui"):
                 resolve_template("package.json.template", app_name=app_name)

--- a/virga/_cli/generators/webui.py
+++ b/virga/_cli/generators/webui.py
@@ -1,4 +1,5 @@
 import shutil
+from typing import Any
 
 from typer import Context
 
@@ -18,7 +19,7 @@ from .base import Generator
 
 class WebUIGenerator(Generator):
     @staticmethod
-    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs):
+    def generate(ctx: Context, app_name: str, project_dir: str, **kwargs: Any) -> None:
         """
         Patch the generated base structure to add mini-strat.
         """

--- a/virga/_cli/templates/auth/app.patch
+++ b/virga/_cli/templates/auth/app.patch
@@ -1,9 +1,9 @@
 --- app.py
 +++ app.py
-@@ -6,1 +6,1 @@
+@@ -8,1 +8,1 @@
 -# from virga.plugins.noct import User, get_current_user
 +from virga.plugins.noct import User, get_current_user
-@@ -47,4 +47,4 @@
+@@ -49,4 +49,4 @@
 -# # Makes use of Noct middleware to fetch the current authenticated user.
 -# @app.get("/user")
 -# async def user_home(current_user: User = Depends(get_current_user)):

--- a/virga/_cli/templates/boilerplate/README.md
+++ b/virga/_cli/templates/boilerplate/README.md
@@ -211,3 +211,9 @@ async def cleanup_context(self, context: Dict[str, Any]):
 ```
 
 If you override the functions of an existing subclass, like `SessionedGraphQLRoute`, ensure to call `super()` in both so the lifecycle of other potential objects is handled correctly (like opening and closing a DB connection).
+
+## Testing
+
+Virga provides a testing plugin, meant for use with pytest, that exposes a few useful mocks and fixtures. That list includes:
+
+- `testing.noct`: Sets up and provides a mock user and relevant tokens for testing authenticated route access via the `mock_user`, `mock_tokens`, and `expired_token` fixtures. These are all session-scoped (for now, PRs welcome).

--- a/virga/_cli/templates/boilerplate/README.md
+++ b/virga/_cli/templates/boilerplate/README.md
@@ -10,7 +10,7 @@ Virga applications, and Virga itself, are [Poetry](https://python-poetry.org/) p
 
 In order to create an app with a UI, you must also install [Yarn](https://yarnpkg.com/getting-started/install).
 
-### 1. Install Poetry and Yarn (assumes Python >= 3.7):
+### 1. Install Poetry and Yarn (assumes Python >= 3.8):
 
   ```sh
   curl -sSL https://install.python-poetry.org | python3 -
@@ -29,6 +29,8 @@ In order to create an app with a UI, you must also install [Yarn](https://yarnpk
   ```
 
   You can create a new project by running `virga new <NAME> [FLAGS]`. This command will generate a new project with the given flags. General command usage and descriptions of available flags are available with `virga new --help`.
+
+  Virga supports Python 3.8+.
 
   See [plugin dependencies](#Plugin-dependencies) for some caveats.
 

--- a/virga/_cli/templates/boilerplate/README.md
+++ b/virga/_cli/templates/boilerplate/README.md
@@ -2,6 +2,8 @@
 
 ![virga status](https://img.shields.io/drone/build/IndicoDataSolutions/virga?label=tests&server=https%3A%2F%2Fdrone.devops.indico.io&style=flat-square)
 
+Indico Data's CLI tool for generating sidecar applications. Sidecar apps are not direct parts of Indico's IPA releases, but offer additional or custom functionality for product or business operations.
+
 ## Generating an app
 
 Virga applications, and Virga itself, are [Poetry](https://python-poetry.org/) projects; they use Poetry as a python dependency and virtual environment manager. To install Poetry, follow the [instructions on its documentation site](https://python-poetry.org/docs/).

--- a/virga/_cli/templates/boilerplate/api/boilerplate/app.py
+++ b/virga/_cli/templates/boilerplate/api/boilerplate/app.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -40,7 +42,7 @@ def pong() -> bool:
 
 
 @app.get("/")
-async def home(settings: Settings = Depends(settings)) -> dict[str, str]:
+async def home(settings: Settings = Depends(settings)) -> Dict[str, str]:
     return {settings.app_name: "Hello World!"}
 
 

--- a/virga/_cli/templates/boilerplate/api/boilerplate/app.py
+++ b/virga/_cli/templates/boilerplate/api/boilerplate/app.py
@@ -31,7 +31,7 @@ app.add_middleware(
 
 
 @app.get("/ping")
-def pong():
+def pong() -> bool:
     """
     Returns HTTP 200 OK when the application is live and ready to receive requests. This
     can be used as a healthcheck endpoint in deployment configurations.
@@ -40,7 +40,7 @@ def pong():
 
 
 @app.get("/")
-async def home(settings: Settings = Depends(settings)):
+async def home(settings: Settings = Depends(settings)) -> dict[str, str]:
     return {settings.app_name: "Hello World!"}
 
 

--- a/virga/_cli/templates/database/app.patch
+++ b/virga/_cli/templates/database/app.patch
@@ -1,6 +1,6 @@
 --- app.py
 +++ app.py
-@@ -12,4 +12,4 @@
+@@ -14,4 +14,4 @@
 -# from sqlalchemy.ext.asyncio import AsyncSession
 -# from sqlalchemy import select
 -# from .database import async_session
@@ -9,7 +9,7 @@
 +from sqlalchemy import select
 +from .database import async_session
 +from .database.models import Widget
-@@ -53,9 +53,9 @@
+@@ -55,9 +55,9 @@
 -# # Spawn an asynchronous database session and fetch a database object.
 -# # https://docs.sqlalchemy.org/en/14/orm/session_basics.html
 -# # https://docs.sqlalchemy.org/en/14/orm/session_basics.html#querying-2-0-style

--- a/virga/_cli/templates/database/database/__init__.py
+++ b/virga/_cli/templates/database/database/__init__.py
@@ -1,4 +1,7 @@
+from typing import AsyncIterator
+
 from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from virga.plugins.database import start_async_session
 
@@ -6,10 +9,12 @@ from ..settings import Settings, settings
 
 
 # https://docs.sqlalchemy.org/en/14/_modules/examples/asyncio/async_orm.html
-async def async_session(settings: Settings = Depends(settings)):
+async def async_session(
+    settings: Settings = Depends(settings),
+) -> AsyncIterator[AsyncSession]:
     session = start_async_session(settings.db_url)
 
     try:
         yield session
     finally:
-        session.close()
+        await session.close()

--- a/virga/_cli/templates/database/database/models/base.py
+++ b/virga/_cli/templates/database/database/models/base.py
@@ -1,3 +1,5 @@
-from sqlalchemy.ext.declarative import declarative_base
+from typing import Type
 
-BASE = declarative_base()
+from sqlalchemy.ext.declarative import declarative_base, DeclarativeMeta
+
+BASE: Type[DeclarativeMeta] = declarative_base()

--- a/virga/_cli/templates/graphql/app.patch
+++ b/virga/_cli/templates/graphql/app.patch
@@ -1,13 +1,13 @@
 --- app.py
 +++ app.py
-@@ -8,3 +8,3 @@
+@@ -10,3 +10,3 @@
 -# from graphene import Schema
 -# from virga.plugins.graphql import SessionedGraphQLRoute
 -# from .gql import RootQuery
 +from graphene import Schema
 +from virga.plugins.graphql import SessionedGraphQLRoute
 +from .gql import RootQuery
-@@ -64,24 +64,24 @@
+@@ -66,24 +66,24 @@
 -# # Mounts a Graphene executor with schema to a route. POST requests to
 -# # the route get executed while GET requests will render GraphiQL. GraphQLRoute
 -# # accepts any Graphene Schema object.

--- a/virga/_cli/templates/graphql/gql.py
+++ b/virga/_cli/templates/graphql/gql.py
@@ -1,4 +1,4 @@
-from graphene import ObjectType, String
+from graphene import ObjectType, String, ResolveInfo
 
 
 #
@@ -7,10 +7,11 @@ from graphene import ObjectType, String
 #
 # https://docs.graphene-python.org/en/stable/execution/execute/
 #
-class ExampleQueryHello(ObjectType):
+class ExampleQueryHello(ObjectType):  # type: ignore
     hello = String(name=String(default_value="Dave"))
 
-    def resolve_hello(self, info, name):
+    @staticmethod
+    def resolve_hello(parent: None, info: ResolveInfo, name: str) -> str:
         return f"Hello {name}!"
 
 
@@ -33,17 +34,18 @@ class ExampleQueryHello(ObjectType):
 # may then be cached and persisted for the duration of the executation
 # chain (all downstream resolvers will have access to it).
 class ExampleDataLoader:
-    def __init__(self, appendage):
+    def __init__(self, appendage: str):
         self.appendage = appendage
 
-    def append_to(self, name):
+    def append_to(self, name: str) -> str:
         return f"{name} {self.appendage}"
 
 
-class ExampleQueryGoodbye(ObjectType):
+class ExampleQueryGoodbye(ObjectType):  # type: ignore
     goodbye = String(name=String(default_value="Stranger"))
 
-    def resolve_goodbye(self, info, name):
+    @staticmethod
+    def resolve_goodbye(parent: None, info: ResolveInfo, name: str) -> str:
         # an instance of ExampleDataLoader does not exist in the context,
         # so a new one will be created and cached. Calling `get_loader`
         # will yield the same literal instance.
@@ -52,7 +54,7 @@ class ExampleQueryGoodbye(ObjectType):
 
 
 #
-# To combine multiple queries or mutations, simple Python multi-inheritence
+# To combine multiple queries or mutations, simple Python multi-inheritance
 # will work. Note that GraphQL is data-centric, so different queries/mutations
 # sharing the same name is nonsensical and not supported --(Data representing
 # different things/operations should not share the same name).

--- a/virga/_cli/utils.py
+++ b/virga/_cli/utils.py
@@ -128,12 +128,13 @@ def apply_patch(patchfile: str, root: Optional[str] = None) -> None:
         os.remove(patchfile)
 
 
-def copy_patch(src: str, dest: str) -> None:
+def copy_patch(src: str, dest: str = "") -> None:
     """
     Copies the provided patch file to the destination, then applies the patch
     using `apply_patch`. The patch is always applied relative to the parent directory
     of the destination, so patches must also specify their sources/destination relative
     to the parent of destination.
     """
+    dest = dest or os.path.basename(src)
     shutil.copy2(get_path(_templates_dir, src), dest)
     apply_patch(dest, root=os.path.dirname(dest))

--- a/virga/_cli/utils.py
+++ b/virga/_cli/utils.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from fileinput import FileInput
 from string import Template
 from subprocess import PIPE, CalledProcessError, run
-from typing import Union, Optional
+from typing import Union, Optional, Generator
 
 from rich import print as rprint
 import patch
@@ -24,13 +24,13 @@ _templates_dir = get_path(os.path.dirname(__file__), "templates")
 _step = 1
 
 
-def _print_step(msg: str):
+def _print_step(msg: str) -> None:
     global _step
     rprint(f"[bold magenta]  {_step}] {msg}")
     _step += 1
 
 
-def run_command(command: str, *args: str):
+def run_command(command: str, *args: str) -> None:
     """
     Run an arbitrary command with arbitrary arguments. STDOUT is preserved
     while STDERR is formatted upon unsuccessful command execution, either at
@@ -63,7 +63,7 @@ def run_command(command: str, *args: str):
 
 
 @contextmanager
-def in_directory(path):
+def in_directory(path: Path) -> Generator[None, None, None]:
     """
     A context manager used to wrap a code block within a change of directory,
     preserving the original working directory and restoring it after block completion.
@@ -77,7 +77,7 @@ def in_directory(path):
         os.chdir(curdir)
 
 
-def resolve_template(file: Path, **variables) -> str:
+def resolve_template(file: Path, **variables: str) -> str:
     """
     Resolves the provided template using the provided variables as placeholders
     and their values. If a placeholder has no found value, it is skipped.
@@ -100,7 +100,7 @@ def resolve_template(file: Path, **variables) -> str:
     return filepath
 
 
-def copy_template(src: Path, dest: Path, **variables) -> str:
+def copy_template(src: Path, dest: Path, **variables: str) -> str:
     """
     Copies a source file to a destination, then resolves the templated destination
     file by passing the provided variables to `resolve_template`.
@@ -109,7 +109,7 @@ def copy_template(src: Path, dest: Path, **variables) -> str:
     return resolve_template(dest, **variables)
 
 
-def apply_patch(patchfile: str, root: Optional[str] = None):
+def apply_patch(patchfile: str, root: Optional[str] = None) -> None:
     """
     Loads, applies, then deletes the given unified patch file, throwing an error
     if something goes wrong. Specifying a root applies the patch relative to
@@ -128,7 +128,7 @@ def apply_patch(patchfile: str, root: Optional[str] = None):
         os.remove(patchfile)
 
 
-def run_patch(src: str, dest: str):
+def run_patch(src: str, dest: str) -> None:
     """
     Copies the provided patch file to the destination, then applies the patch
     using `apply_patch`. The patch is always applied relative to the parent directory

--- a/virga/_cli/utils.py
+++ b/virga/_cli/utils.py
@@ -105,7 +105,7 @@ def copy_template(src: Path, dest: Path, **variables: str) -> str:
     Copies a source file to a destination, then resolves the templated destination
     file by passing the provided variables to `resolve_template`.
     """
-    shutil.copy2(src, dest)
+    shutil.copy2(get_path(_templates_dir, src), dest)
     return resolve_template(dest, **variables)
 
 
@@ -128,12 +128,12 @@ def apply_patch(patchfile: str, root: Optional[str] = None) -> None:
         os.remove(patchfile)
 
 
-def run_patch(src: str, dest: str) -> None:
+def copy_patch(src: str, dest: str) -> None:
     """
     Copies the provided patch file to the destination, then applies the patch
     using `apply_patch`. The patch is always applied relative to the parent directory
     of the destination, so patches must also specify their sources/destination relative
     to the parent of destination.
     """
-    shutil.copy2(src, dest)
+    shutil.copy2(get_path(_templates_dir, src), dest)
     apply_patch(dest, root=os.path.dirname(dest))

--- a/virga/_cli/utils.py
+++ b/virga/_cli/utils.py
@@ -6,7 +6,7 @@ from string import Template
 from subprocess import PIPE, CalledProcessError, run
 from typing import Union, Optional
 
-import click
+from rich import print as rprint
 import patch
 
 Path = Union[str, os.PathLike]
@@ -26,7 +26,7 @@ _step = 1
 
 def _print_step(msg: str):
     global _step
-    click.secho(f"  {_step}] {msg}", fg="magenta", bold=True)
+    rprint(f"[bold magenta]  {_step}] {msg}")
     _step += 1
 
 
@@ -52,16 +52,13 @@ def run_command(command: str, *args: str):
         # if the command failed, we only care about its stderr
         if isinstance(err, CalledProcessError):
             err = err.stderr
-        errmsg = click.style(f"\n\n{err}", dim=True) if str(err) else ""
+        errmsg = f"[dim]\n\n{err}" if str(err) else ""
 
         # the subprocess failed due to an OS exception or an invalid command, so
         # print a nice message instead of throwing a runtime exception
-        click.get_current_context().fail(
-            click.style(
-                f"The command `{' '.join(cmd)}` was attempted, but failed. The"
-                " output was recaptured and is printed."
-            )
-            + errmsg
+        raise Exception(
+            f"The command `{' '.join(cmd)}` was attempted, but failed. The"
+            " output was recaptured and is printed." + errmsg
         )
 
 
@@ -124,7 +121,7 @@ def apply_patch(patchfile: str, root: Optional[str] = None):
         pset = patch.fromfile(patchfile)
 
         if not pset or not pset.apply(root=root):
-            raise Exception("Malformed patch. This is a bug :(")
+            raise Exception("Malformed patch. This is a bug :bug:")
     except Exception:
         raise
     finally:

--- a/virga/plugins/graphql/__init__.py
+++ b/virga/plugins/graphql/__init__.py
@@ -1,2 +1,4 @@
-from .route import GraphQLRoute  # noqa
-from .sessioned import SessionedGraphQLRoute  # noqa
+from .route import GraphQLRoute
+from .sessioned import SessionedGraphQLRoute
+
+__all__ = ["GraphQLRoute", "SessionedGraphQLRoute"]

--- a/virga/plugins/graphql/route.py
+++ b/virga/plugins/graphql/route.py
@@ -10,10 +10,10 @@ from starlette.types import Receive, Scope, Send
 # complain if graphql extra isn't installed
 try:
     import graphene
-    from graphql import format_error
+    from graphql import format_error  # type: ignore
     from graphql.execution.executors.asyncio import AsyncioExecutor
 except ImportError:
-    graphene = None  # type: ignore
+    graphene = None
 
 
 GRAPHIQL = str(pathlib.Path(__file__).parent / "graphiql.html")
@@ -97,12 +97,14 @@ class GraphQLRoute:
             response, status_code=status.HTTP_200_OK, background=background
         )
 
-    def _build_context_cache(self, context):
+    def _build_context_cache(self, context: Dict[str, Any]) -> None:
         # Allow loader and request caching through the request context and get_* methods
-        loaders: Dict[Callable, Any] = {}
-        clients: Dict[Callable, Any] = {}
+        loaders: Dict[Callable[..., Any], Any] = {}
+        clients: Dict[Callable[..., Any], Any] = {}
 
-        def get_loaders(loader_type, *args: Any, **kwargs: Any):
+        def get_loaders(
+            loader_type: Callable[..., Any], *args: Any, **kwargs: Any
+        ) -> Any:
             loader = loaders.get(loader_type)
 
             if not loader:
@@ -111,7 +113,9 @@ class GraphQLRoute:
 
             return loader
 
-        def get_clients(client_type, *args: Any, **kwargs: Any):
+        def get_clients(
+            client_type: Callable[..., Any], *args: Any, **kwargs: Any
+        ) -> Any:
             client = clients.get(client_type)
 
             if not client:
@@ -123,14 +127,14 @@ class GraphQLRoute:
         context["get_loader"] = get_loaders
         context["get_client"] = get_clients
 
-    async def setup_context(self, context: Dict[str, Any]):
+    async def setup_context(self, context: Dict[str, Any]) -> None:
         """
         Allows customization of the GraphQL context. This gets run before the executor
         resolves the GraphQL request.
         """
         pass
 
-    async def cleanup_context(self, context: Dict[str, Any]):
+    async def cleanup_context(self, context: Dict[str, Any]) -> None:
         """
         Allows cleanup of any objects stored within the GraphQL context. This gets run
         after the executor resolves the GraphQL request and generates a response.

--- a/virga/plugins/noct/__init__.py
+++ b/virga/plugins/noct/__init__.py
@@ -1,5 +1,17 @@
-from .errors import *  # noqa
-from .handler import _NOCT_COOKIE_DOMAIN as VALID_DOMAIN  # noqa
-from .handler import _NOCT_SERVICE_LOCATION as NOCT_URL  # noqa
-from .handler import get_current_user, read_user  # noqa
-from .user import User  # noqa
+from .errors import LoginRequiredException, ExpiredTokenException
+from .handler import _NOCT_COOKIE_DOMAIN as VALID_DOMAIN
+from .handler import _NOCT_SERVICE_LOCATION as NOCT_URL
+from .handler import get_current_user, read_user
+from .typing import NoctCookie
+from .user import User
+
+__all__ = [
+    "LoginRequiredException",
+    "ExpiredTokenException",
+    "VALID_DOMAIN",
+    "NOCT_URL",
+    "get_current_user",
+    "read_user",
+    "NoctCookie",
+    "User",
+]

--- a/virga/plugins/noct/errors.py
+++ b/virga/plugins/noct/errors.py
@@ -2,7 +2,7 @@ from fastapi import HTTPException, status
 
 
 class LoginRequiredException(HTTPException):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Login is required to access this route",
@@ -11,7 +11,7 @@ class LoginRequiredException(HTTPException):
 
 
 class ExpiredTokenException(HTTPException):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Access token is expired",

--- a/virga/plugins/noct/typing.py
+++ b/virga/plugins/noct/typing.py
@@ -1,0 +1,17 @@
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+NoctCookie = TypedDict(
+    "NoctCookie",
+    {
+        "key": str,
+        "value": str,
+        "domain": str,
+        "httponly": bool,
+        "secure": bool,
+    },
+)

--- a/virga/plugins/noct/typing.py
+++ b/virga/plugins/noct/typing.py
@@ -1,9 +1,4 @@
-import sys
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
+from typing import TypedDict
 
 NoctCookie = TypedDict(
     "NoctCookie",

--- a/virga/plugins/noct/user.py
+++ b/virga/plugins/noct/user.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List, Any
 
 from pydantic import BaseModel
 
@@ -9,9 +9,10 @@ class User(BaseModel):
     id: str
     email: str
     name: Optional[str] = None
-    scopes: Optional[list] = None
+    scopes: Optional[List[str]] = None
 
-    def __init__(self, **data):
+    def __init__(self, **data: Any):
+        """Parse the noct payload into user properties."""
         fields = {}
 
         for k, v in data.items():

--- a/virga/plugins/secure_cookies/__init__.py
+++ b/virga/plugins/secure_cookies/__init__.py
@@ -1,1 +1,3 @@
-from .secure_cookies import read_secure_cookie, write_secure_cookie  # noqa
+from .secure_cookies import read_secure_cookie, write_secure_cookie
+
+__all__ = ["read_secure_cookie", "write_secure_cookie"]

--- a/virga/plugins/secure_cookies/secure_cookies.py
+++ b/virga/plugins/secure_cookies/secure_cookies.py
@@ -58,7 +58,9 @@ def _create_signature_v2(secret: str, s: bytes) -> bytes:
     return utf8_bytes(hash.hexdigest())
 
 
-def _decode_signed_value_v2(name: str, value: bytes, max_age_days) -> Optional[bytes]:
+def _decode_signed_value_v2(
+    name: str, value: bytes, max_age_days: int
+) -> Optional[bytes]:
     try:
         timestamp_bytes, name_field, value_field, passed_sig = _decode_fields_v2(value)
     except Exception:
@@ -108,10 +110,15 @@ def _encode_signed_value_v2(name: str, value: bytes) -> bytes:
     return to_sign + signature
 
 
-def read_secure_cookie(name: str, value: str, max_age_days: int = 31) -> Optional[str]:
+def read_secure_cookie(
+    name: str, value: Optional[str], max_age_days: int = 31
+) -> Optional[str]:
     """
     Decodes a version 2 secure cookie encoded by Atmosphere/Tornado.
     """
+    if not value:
+        raise Exception()
+
     # Cookies may or may not be quoted per RFC 6265
     # https://tools.ietf.org/html/rfc6265#section-4.1.1
     value = _unquote_cookie(value)

--- a/virga/plugins/testing/noct.py
+++ b/virga/plugins/testing/noct.py
@@ -11,8 +11,9 @@ try:
 except ImportError:
     jwt = None  # type: ignore
 
-from http.cookies import SimpleCookie
 from datetime import datetime, timedelta
+from http.cookies import SimpleCookie
+from typing import Dict, Tuple, Union
 
 from virga.plugins.noct import NOCT_URL, VALID_DOMAIN
 from virga.plugins.noct.handler import _NOCT_JWT_ALGORITHM, _NOCT_JWT_SECRET
@@ -20,7 +21,7 @@ from virga.plugins.secure_cookies import write_secure_cookie
 
 
 @pytest.fixture(scope="session")
-def mock_user():
+def mock_user() -> Dict[str, Union[str, int]]:
     """Returns a the credentipytestals and unique id of a registered Noct user."""
     password = "P@ssw0rd!"
     name = "Mock User"
@@ -37,7 +38,7 @@ def mock_user():
 
 
 @pytest.fixture(scope="session")
-def mock_tokens(mock_user):
+def mock_tokens(mock_user: Dict[str, Union[str, int]]) -> Tuple[str, str, str, str]:
     """
     Returns the valid authentication and refresh tokens for a Mock User. The first two
     tokens are encrypted and can be used for making authenticated calls, while the
@@ -57,7 +58,7 @@ def mock_tokens(mock_user):
         # https://github.com/psf/requests/issues/6344
         # if the above failed, its likely to do this, but we can pull the cookie
         # out of the header instead
-        jar: SimpleCookie = SimpleCookie(res.headers["Set-Cookie"])
+        jar: SimpleCookie[str] = SimpleCookie(res.headers["Set-Cookie"])
         from_cookie = (jar["auth_token"].value, jar["refresh_token"].value)
 
     # the first two are the encrypted versions returned by Noct
@@ -70,7 +71,7 @@ def mock_tokens(mock_user):
 
 
 @pytest.fixture(scope="session")
-def expired_token(mock_user):
+def expired_token(mock_user: Dict[str, Union[str, int]]) -> str:
     """
     Returns an encrypted but expired (by 1 minute) authentication token for a Mock User.
     """

--- a/virga/plugins/testing/noct.py
+++ b/virga/plugins/testing/noct.py
@@ -22,7 +22,7 @@ from virga.plugins.secure_cookies import write_secure_cookie
 
 @pytest.fixture(scope="session")
 def mock_user() -> Dict[str, Union[str, int]]:
-    """Returns a the credentipytestals and unique id of a registered Noct user."""
+    """Returns a the credentials and unique id of a registered Noct user."""
     password = "P@ssw0rd!"
     name = "Mock User"
     email = "mockuser@indicodata.ai"


### PR DESCRIPTION
## Summary

- Prettier interface via Typer (ex. [here](https://typer.tiangolo.com/#run-it)).
- New `virga --version` and autocomplete installation commands.
- Misc internal cleanups.
- Greatly fix & improve mypy typing.
- Fix automatic async session closing within FastAPI dependency.
- Pin SQLAlchemy version in the `database` extra to `=~1.4`.
- Bump minimum Python version from 3.7 to 3.8.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
